### PR TITLE
add vultr and cloudstack collections

### DIFF
--- a/2.10/acd.in
+++ b/2.10/acd.in
@@ -43,6 +43,8 @@ netapp.aws
 netapp.elementsw
 netapp.ontap
 netbox.netbox
+ngine_io.cloudstack
+ngine_io.vultr
 openstack.cloud
 openvswitch.openvswitch
 #ovirt.ovirt


### PR DESCRIPTION
These collections has been removed from community general into their own
collection under the ngine_io namespace:

- https://github.com/ansible-collections/community.general/pull/173
- https://github.com/ansible-collections/community.general/pull/172
- https://github.com/ansible/ansible/pull/68916
- https://github.com/ansible/ansible/pull/68917