### PR TITLE
dedicated collection for cloudscale.ch related plugins

### DIFF
--- a/2.10/acd.in
+++ b/2.10/acd.in
@@ -16,6 +16,7 @@ cisco.meraki
 cisco.mso
 cisco.nxos
 cisco.ucs
+cloudscale_ch.cloud
 community.aws
 community.azure
 community.crypto


### PR DESCRIPTION
A vendor supported dedicated collections [cloudscale_ch.cloud](https://galaxy.ansible.com/cloudscale_ch/cloud) based on the community.general modules (I and vendor were the only community).
