### PR TITLE
infobox.nios_modules (not available yet)

### DIFF
--- a/2.10/acd.in
+++ b/2.10/acd.in
@@ -44,6 +44,7 @@ frr.frr
 google.cloud
 hetzner.hcloud
 ibm.qradar
+#infobox.nios_modules # https://github.com/infobloxopen/infoblox-ansible/issues/7
 junipernetworks.junos
 # mellanox.onyx
 netapp.aws


### PR DESCRIPTION
Just found that NIOS has been split into its own Collection.
Though they've got a fair bit of work to do https://github.com/infobloxopen/infoblox-ansible/issues/7