### PR TITLE
community.proxysql

### DIFF
--- a/2.10/acd.in
+++ b/2.10/acd.in
@@ -26,6 +26,7 @@ community.kubernetes
 community.libvirt
 community.mongodb
 community.network
+#community.proxysql
 community.rabbitmq
 community.vmware
 community.windows


### PR DESCRIPTION
community.proxysql should be live within the next ~5 days.
Once this is has been published to Galaxy (which I'll do) we can uncomment this line so it's included in the next build of the `ansible` package.

This is been driven by `persysted` (Freenode) (@bmildren)