### PR TITLE
Remove global changelog entries moved to collection changelogs

### DIFF
--- a/2.10/changelog.yaml
+++ b/2.10/changelog.yaml
@@ -3,14 +3,6 @@ releases:
   2.10.0a1:
     changes:
       breaking_changes:
-      - "ansible.windows.win_find - module has been refactored to better match the
-        behaviour of the ``find`` module. Here is what has changed:\n  * When the
-        directory specified by ``paths`` does not exist or is a file, it will no longer
-        fail and will just warn the user\n  * Junction points are no longer reported
-        as ``islnk``, use ``isjunction`` to properly report these files. This behaviour
-        matches the ansible.windows.win_stat module\n  * Directories no longer return
-        a ``size``, this matches the ``stat`` and ``find`` behaviour and has been
-        removed due to the difficulties in correctly reporting the size of a directory\n"
       - cisco.nxos.nxos_igmp_interface - no longer supports the deprecated ``oif_prefix``
         and ``oif_source`` options. These have been superceeded by ``oif_ps``.
       - community.grafana.grafana_dashboard - the parameter ``message`` is renamed
@@ -24,19 +16,6 @@ releases:
       deprecated_features:
       - The vyos.vyos.vyos_static_route module has been deprecated and will be removed
         in a later release; use vyos.vyos.vyos_static_routes instead.
-      - ansible.windows.win_domain_controller - the ``log_path`` option has been deprecated
-        and will be removed in a later release. This was undocumented and only related
-        to debugging information for module development.
-      - ansible.windows.win_package - the ``ensure`` alias for the ``state`` option
-        has been deprecated and will be removed in a later release. Please use ``state``
-        instead of ``ensure``.
-      - ansible.windows.win_package - the ``productid`` alias for the ``product_id``
-        option has been deprecated and will be removed in a later release. Please
-        use ``product_id`` instead of ``productid``.
-      - 'ansible.windows.win_package - the ``username`` and ``password`` options has
-        been deprecated and will be removed in a later release. The same functionality
-        can be done by using ``become: yes`` and ``become_flags: logon_type=new_credentials
-        logon_flags=netcredentials_only`` on the task.'
       release_summary: 'Release Date: 2020-06-18
 
 
@@ -44,8 +23,6 @@ releases:
 
         '
       removed_features:
-      - ansible.windows.win_stat - removed the deprecated ``get_md55`` option and
-        ``md5`` return value.
       - community.windows.win_psexec - removed the deprecated ``extra_opts`` option.
     release_date: '2020-06-18'
   2.10.0a2:

--- a/2.10/changelog.yaml
+++ b/2.10/changelog.yaml
@@ -7,10 +7,6 @@ releases:
         and ``oif_source`` options. These have been superceeded by ``oif_ps``.
       - community.grafana.grafana_dashboard - the parameter ``message`` is renamed
         to ``commit_message`` since ``message`` is used by Ansible Core engine internally.
-      - community.windows.win_pester - no longer runs all ``*.ps1`` file in the directory
-        specified due to it executing potentially unknown scripts. It will follow
-        the default behaviour of only running tests for files that are like ``*.tests.ps1``
-        which is built into Pester itself.
       - purestorage.flashblade.purefb_fs - no longer supports the deprecated ``nfs``
         option. This has been superceeded by ``nfsv3``.
       deprecated_features:
@@ -22,8 +18,6 @@ releases:
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_
 
         '
-      removed_features:
-      - community.windows.win_psexec - removed the deprecated ``extra_opts`` option.
     release_date: '2020-06-18'
   2.10.0a2:
     changes:


### PR DESCRIPTION
Will clean up entries when the following PRs are merged:
- [x] ansible-collections/community.general#703 (merged in #25)
- [x] ansible-collections/vmware#325 (merged in #30)
- [x] ansible-collections/ansible.windows#85
- [x] ansible-collections/community.windows#119, ansible-collections/community.windows#121
- [x] ansible-collections/amazon.aws#118 (merged in #30)
- [x] ansible-collections/community.aws#165 (merged in #30)
