### PR TITLE
Add ancestor to changelog.yaml

### DIFF
--- a/2.10/changelog.yaml
+++ b/2.10/changelog.yaml
@@ -1,3 +1,4 @@
+ancestor: 2.9.0
 releases:
   2.10.0a1:
     changes:


### PR DESCRIPTION
This essentially says that the changelog describes changes that happened since Ansible 2.9.0.