### PR TITLE
Add community.hrobot

### DIFF
--- a/2.10/ansible.in
+++ b/2.10/ansible.in
@@ -24,6 +24,7 @@ community.digitalocean
 community.docker
 community.general
 community.grafana
+community.hrobot
 community.kubernetes
 community.libvirt
 community.mongodb


### PR DESCRIPTION
1.0.0 has been [released](https://galaxy.ansible.com/community/hrobot), and I'm pretty sure it follows as rules from the checklist.