### PR TITLE
Add community.okd, a collection which was broken out of the community.general collection, for 2.10.4

### DIFF
--- a/2.10/ansible-2.10.build
+++ b/2.10/ansible-2.10.build
@@ -30,6 +30,7 @@ community.libvirt: >=1.0.0,<2.0.0
 community.mongodb: >=1.0.0,<2.0.0
 community.mysql: >=1.0.0,<2.0.0
 community.network: >=1.1.0,<2.0.0
+community.okd: >=1.0.0,<2.0.0
 community.proxysql: >=1.0.0,<2.0.0
 community.rabbitmq: >=1.0.0,<2.0.0
 community.skydive: >=1.0.0,<2.0.0

--- a/2.10/ansible.in
+++ b/2.10/ansible.in
@@ -30,6 +30,7 @@ community.libvirt
 community.mongodb
 community.mysql
 community.network
+community.okd
 community.postgresql
 community.proxysql
 community.rabbitmq


### PR DESCRIPTION
These are the changes needed to add a new collection to a stable release.  In this PR we add community.okd which was spun out of community.general and thus is allowed into 2.10.x according to the policies approved at the community irc meeting.

I had to do this manually (add the collection name to ansible.in and look on galaxy.ansible.com for the current version and add the collection with the appropriate version range to the ansible-2.10.build file.)  I've opened a ticket on the antsibull repo to add code to do that at some point in the future.

