### PR TITLE
Migrate Cisco NSO modules from community.network to cisco.nso

### DIFF
--- a/2.10/ansible-2.10.build
+++ b/2.10/ansible-2.10.build
@@ -16,6 +16,7 @@ cisco.ios: >=1.0.0,<2.0.0
 cisco.iosxr: >=1.0.0,<2.0.0
 cisco.meraki: >=2.0.0,<3.0.0
 cisco.mso: >=1.0.0,<2.0.0
+cisco.nso: >=1.0.0,<2.0.0
 cisco.nxos: >=1.1.0,<2.0.0
 cisco.ucs: >=1.5.0,<2.0.0
 cloudscale_ch.cloud: >=1.1.0,<2.0.0

--- a/2.10/ansible.in
+++ b/2.10/ansible.in
@@ -14,6 +14,7 @@ cisco.ios
 cisco.iosxr
 cisco.meraki
 cisco.mso
+cisco.nso
 cisco.nxos
 cisco.ucs
 cloudscale_ch.cloud


### PR DESCRIPTION
Including cisco.nso in ansible.in per PR https://github.com/ansible-collections/community.network/pull/142 and 
https://github.com/CiscoDevNet/ansible-nso/issues/4
