### PR TITLE
Add community.hashi_vault to 2.10 and 3; add community.google to 3

### DIFF
--- a/2.10/ansible-2.10.build
+++ b/2.10/ansible-2.10.build
@@ -28,6 +28,7 @@ community.docker: >=1.0.0,<2.0.0
 community.general: >=1.1.0,<2.0.0
 community.google: >=1.0.0,<2.0.0
 community.grafana: >=1.0.0,<2.0.0
+community.hashi_vault: >=1.0.0,<2.0.0
 community.hrobot: >=1.0.0,<2.0.0
 community.kubernetes: >=1.0.0,<2.0.0
 community.libvirt: >=1.0.0,<2.0.0

--- a/2.10/ansible.in
+++ b/2.10/ansible.in
@@ -26,6 +26,7 @@ community.docker
 community.general
 community.google
 community.grafana
+community.hashi_vault
 community.hrobot
 community.kubernetes
 community.libvirt

--- a/3/ansible.in
+++ b/3/ansible.in
@@ -24,6 +24,7 @@ community.crypto
 community.digitalocean
 community.docker
 community.general
+community.google
 community.grafana
 community.hashi_vault
 community.hrobot

--- a/3/ansible.in
+++ b/3/ansible.in
@@ -25,6 +25,7 @@ community.digitalocean
 community.docker
 community.general
 community.grafana
+community.hashi_vault
 community.hrobot
 community.kubernetes
 community.libvirt


### PR DESCRIPTION
[community.hashi_vault 1.0.0](https://galaxy.ansible.com/community/hashi_vault) has been released. It contains the hashi_vault lookup plugin that's migrated from community.general.

Also, since 3/ansible.in is already there, new collections should be added there as well. Since community.google wasn't added there in #45, I'm adding it in this PR as well.

CC @briantist