### PR TITLE
Add community.kubevirt to 2.10 and 3

### DIFF
--- a/2.10/ansible-2.10.build
+++ b/2.10/ansible-2.10.build
@@ -31,6 +31,7 @@ community.grafana: >=1.0.0,<2.0.0
 community.hashi_vault: >=1.0.0,<2.0.0
 community.hrobot: >=1.0.0,<2.0.0
 community.kubernetes: >=1.0.0,<2.0.0
+community.kubevirt: >=1.0.0,<2.0.0
 community.libvirt: >=1.0.0,<2.0.0
 community.mongodb: >=1.0.0,<2.0.0
 community.mysql: >=1.0.0,<2.0.0

--- a/2.10/ansible.in
+++ b/2.10/ansible.in
@@ -29,6 +29,7 @@ community.grafana
 community.hashi_vault
 community.hrobot
 community.kubernetes
+community.kubevirt
 community.libvirt
 community.mongodb
 community.mysql

--- a/3/ansible.in
+++ b/3/ansible.in
@@ -29,6 +29,7 @@ community.grafana
 community.hashi_vault
 community.hrobot
 community.kubernetes
+community.kubevirt
 community.libvirt
 community.mongodb
 community.mysql


### PR DESCRIPTION
1.0 was released and it's contents were migrated from community.general.