### PR TITLE
Include t_systems_mms.icinga_director for Ansible 3.0

### DIFF
--- a/3/ansible.in
+++ b/3/ansible.in
@@ -78,5 +78,6 @@ purestorage.flashblade
 servicenow.servicenow
 splunk.es
 theforeman.foreman
+t_systems_mms.icinga_director
 vyos.vyos
 wti.remote


### PR DESCRIPTION
This collection was reviewed and meets the criteria agreed upon by the
Ansible community and its inclusion to Ansible 3.0 has been approved.

The history of the application as well as the review is available at:
https://github.com/ansible-collections/ansible-inclusion/discussions/5