### PR TITLE
Include dellemc.openmanage collection for Ansible 3.0

### DIFF
--- a/3/ansible.in
+++ b/3/ansible.in
@@ -48,6 +48,7 @@ community.zabbix
 containers.podman
 cyberark.conjur
 cyberark.pas
+dellemc.openmanage
 dellemc.os10
 dellemc.os6
 dellemc.os9

--- a/3/collection-meta.yaml
+++ b/3/collection-meta.yaml
@@ -1,5 +1,8 @@
 ---
 collections:
+  dellemc.openmanage:
+    maintainers:
+      - rajeevarakkal
   community.sops:
     maintainers:
       - endorama

--- a/3/collection-meta.yaml
+++ b/3/collection-meta.yaml
@@ -1,6 +1,7 @@
 ---
 collections:
   dellemc.openmanage:
+    changelog-url: https://github.com/dell/dellemc-openmanage-ansible-modules/blob/collections/CHANGELOG.rst
     maintainers:
       - rajeevarakkal
   community.sops:


### PR DESCRIPTION
The history of the application as well as the review is available at:
https://github.com/ansible-collections/ansible-inclusion/discussions/3