### PR TITLE
Include kubernetes.core in ansible-3

### DIFF
--- a/3/ansible.in
+++ b/3/ansible.in
@@ -62,6 +62,9 @@ ibm.qradar
 infinidat.infinibox
 #infobox.nios_modules # NOT FOR 2.10 https://github.com/infobloxopen/infoblox-ansible/issues/7
 junipernetworks.junos
+# community.kubernetes shall be renamed to kubernetes.core, they are already the same build artifact
+# https://github.com/ansible-collections/community.kubernetes/issues/221
+kubernetes.core
 mellanox.onyx
 netapp.aws
 netapp.elementsw

--- a/3/collection-meta.yaml
+++ b/3/collection-meta.yaml
@@ -15,6 +15,7 @@ collections:
       - rndmh3ro
       - schurzi
   kubernetes.core:
-    changelog-url: https://github.com/ansible-collections/community.kubernetes/blob/main/CHANGELOG.rst
     maintainers:
-      - Ansible Cloud Team
+      - jillr
+      - akasurde
+      - gravesm

--- a/3/collection-meta.yaml
+++ b/3/collection-meta.yaml
@@ -14,3 +14,7 @@ collections:
     maintainers:
       - rndmh3ro
       - schurzi
+  kubernetes.core:
+    changelog-url: https://github.com/ansible-collections/community.kubernetes/blob/main/CHANGELOG.rst
+    maintainers:
+      - Ansible Cloud Team


### PR DESCRIPTION
The community.kubernetes will be renamed to kubernetes.core with its future 2.0 release.
The contents of the community.kubernetes repo are being published to both collection
names on Galaxy today (1.x.x series).
community.okd versions >= 1.0.1 depend on the name kubernetes.core.
https://github.com/ansible-collections/community.kubernetes/issues/221