### PR TITLE
[WIP] Restrict community.okd to 1.0.0 for Ansible 2.10

### DIFF
--- a/2.10/ansible-2.10.build
+++ b/2.10/ansible-2.10.build
@@ -37,7 +37,7 @@ community.libvirt: >=1.0.0,<2.0.0
 community.mongodb: >=1.0.0,<2.0.0
 community.mysql: >=1.0.0,<2.0.0
 community.network: >=1.1.0,<2.0.0
-community.okd: >=1.0.0,<2.0.0
+community.okd: ==1.0.0
 community.postgresql: >=1.0.0,<2.0.0
 community.proxysql: >=1.0.0,<2.0.0
 community.rabbitmq: >=1.0.0,<2.0.0

--- a/2.10/changelog.yaml
+++ b/2.10/changelog.yaml
@@ -196,3 +196,10 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2021-01-26'
+  2.10.7:
+    changes:
+      major_changes:
+        - Restricting the version of the community.okd collection to 1.0.0. The previously included version,
+          1.0.1, had a dependency on kubernetes.core and thus required the installation of an additional
+          collection that was not included in Ansible 2.10. Version 1.0.0 is essentially identical to 1.0.1,
+          except that it uses community.kubernetes, wihch is included in Ansible 2.10.

--- a/2.10/changelog.yaml
+++ b/2.10/changelog.yaml
@@ -199,7 +199,8 @@ releases:
   2.10.7:
     changes:
       major_changes:
-        - Restricting the version of the community.okd collection to 1.0.0. The previously included version,
-          1.0.1, had a dependency on kubernetes.core and thus required the installation of an additional
-          collection that was not included in Ansible 2.10. Version 1.0.0 is essentially identical to 1.0.1,
-          except that it uses community.kubernetes, wihch is included in Ansible 2.10.
+      - Restricting the version of the community.okd collection to 1.0.0. The previously
+        included version, 1.0.1, had a dependency on kubernetes.core and thus required
+        the installation of an additional collection that was not included in Ansible
+        2.10. Version 1.0.0 is essentially identical to 1.0.1, except that it uses
+        community.kubernetes, wihch is included in Ansible 2.10.


### PR DESCRIPTION
I've added a changelog entry for this change explaining it. 

Before this is done, I have to test how antsibull-build reacts on an existing changelog for a new version. This might either require a fix to antsibull, or some more manual work during release. (Since this should be easier in the future, I prefer a fix to antsibull). Or maybe it already works as expected, I haven't tried this for a long time :)