### PR TITLE
Add accepted candidates to the Ansible 5 build data

### DIFF
--- a/5/ansible.in
+++ b/5/ansible.in
@@ -18,6 +18,7 @@ cisco.mso
 cisco.nso
 cisco.nxos
 cisco.ucs
+cloud.common
 cloudscale_ch.cloud
 community.aws
 community.azure
@@ -66,7 +67,7 @@ hetzner.hcloud
 hpe.nimble
 ibm.qradar
 infinidat.infinibox
-#infobox.nios_modules # NOT FOR 2.10 https://github.com/infobloxopen/infoblox-ansible/issues/7
+infobox.nios_modules
 inspur.sm
 junipernetworks.junos
 # community.kubernetes shall be renamed to kubernetes.core, they are already the same build artifact
@@ -79,6 +80,7 @@ netapp.cloudmanager
 netapp.elementsw
 netapp_eseries.santricity
 netapp.ontap
+netapp.storagegrid
 netapp.um_info
 netbox.netbox
 ngine_io.cloudstack

--- a/5/collection-meta.yaml
+++ b/5/collection-meta.yaml
@@ -56,3 +56,17 @@ collections:
   community.dns:
     maintainers:
       - felixfontein
+  cloud.common:
+    maintainers:
+      - Akasurde
+      - abikouo
+      - goneri
+      - jillr
+  infoblox.nios_modules:
+    maintainers:
+      - anagha-infoblox
+  netapp.storagegrid:
+    maintainers:
+      - carchi8py
+      - jkandati
+      - joshedmonds


### PR DESCRIPTION
This commit adds three collections to the Ansible 5 build data:

  * cloud.common,
  * infoblox.nios_modules, and
  * netapp.storagegrid.

Link to the meeting minutes with votes:

https://meetbot.fedoraproject.org/ansible-community/2021-10-20/ansible_community_meeting.2021-10-20-18.00.html