### PR TITLE
Fix spelling error in infoblox namespace

### DIFF
--- a/5/ansible.in
+++ b/5/ansible.in
@@ -67,7 +67,7 @@ hetzner.hcloud
 hpe.nimble
 ibm.qradar
 infinidat.infinibox
-infobox.nios_modules
+infoblox.nios_modules
 inspur.sm
 junipernetworks.junos
 # community.kubernetes shall be renamed to kubernetes.core, they are already the same build artifact


### PR DESCRIPTION
This is what caused the docs builds to fail...

`   retval = await self._get_galaxy_versions(galaxy_url)
  File "/home/samccann/new-ansible/lib64/python3.9/site-packages/antsibull/galaxy.py", line 80, in _get_galaxy_versions
    raise NoSuchCollection(f'No collection found at: {versions_url}')
antsibull.galaxy.NoSuchCollection: No collection found at: https://galaxy.ansible.com/api/v2/collections/infobox/nios_modules/versions/
`