### PR TITLE
CI: Use version 5.10.0 to test builds in CI

### DIFF
--- a/.github/workflows/antsibull-build-default.yml
+++ b/.github/workflows/antsibull-build-default.yml
@@ -37,12 +37,14 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install poetry ansible-core
 
+      # Using ansible_version as 5.10.0 since it is unreleased so new deps are generated
       - name: Test building a release with the defaults
         working-directory: antsibull
         run: |
           ansible-playbook -vv playbooks/build-single-release.yaml \
           -e 'antsibull_build_command="poetry run coverage run -p --source antsibull -m antsibull.cli.antsibull_build"' \
-          -e antsibull_data_reset=false
+          -e antsibull_data_reset=false \
+          -e antsibull_ansible_version=5.10.0
 
       - name: Combine and upload coverage stats
         working-directory: antsibull


### PR DESCRIPTION
The purpose of the job is to build what would be the next version of
ansible, including the changes of the PR, to see if it works.

We were trying to build ansible 5.0.0 in the job because that's what the
role defaults to.

Specify a future (unreleased) version so we can test the build properly.