### PR TITLE
Remove community.kubevirt from Ansible 6

### DIFF
--- a/6/ansible-6.build
+++ b/6/ansible-6.build
@@ -37,7 +37,6 @@ community.grafana: >=1.3.0,<2.0.0
 community.hashi_vault: >=2.4.0,<3.0.0
 community.hrobot: >=1.2.0,<2.0.0
 community.kubernetes: >=2.0.0,<3.0.0
-community.kubevirt: >=1.0.0,<2.0.0
 community.libvirt: >=1.0.0,<2.0.0
 community.mongodb: >=1.3.0,<2.0.0
 community.mysql: >=3.1.0,<4.0.0

--- a/6/ansible.in
+++ b/6/ansible.in
@@ -35,7 +35,6 @@ community.grafana
 community.hashi_vault
 community.hrobot
 community.kubernetes
-community.kubevirt
 community.libvirt
 community.mongodb
 community.mysql

--- a/6/changelog.yaml
+++ b/6/changelog.yaml
@@ -7,3 +7,13 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2022-04-12'
+  6.0.0a2:
+    changes:
+      removed_features:
+        - The community.kubevirt collection has been removed from Ansible 6.
+          It has not been working with the community.kubernetes collection included
+          since Ansible 5.0.0, and unfortunately nobody managed to adjust the
+          collection to work with kubernetes.core >= 2.0.0. If you need to use this
+          collection, you need to manually install community.kubernetes < 2.0.0
+          together with community.kubevirt
+          (https://github.com/ansible-community/community-topics/issues/92).


### PR DESCRIPTION
Removal of broken collection community.kubevirt from Ansible 6 (ansible-community/community-topics#92).

cc @felixfontein 