### PR TITLE
GHA: Update job to install poetry

### DIFF
--- a/.github/workflows/antsibull-build-6.yml
+++ b/.github/workflows/antsibull-build-6.yml
@@ -64,7 +64,7 @@ jobs:
         working-directory: antsibull
         run: |
           ansible-playbook -vv playbooks/build-single-release.yaml \
-            -e antsibull_build_command="poetry run antsibull-build" \
+            -e 'antsibull_build_command="poetry run antsibull-build"' \
             -e antsibull_build_file=ansible-6.build \
             -e antsibull_ansible_version=6.99.0 \
             -e antsibull_data_dir="{{ antsibull_data_git_dir }}/6" \

--- a/.github/workflows/antsibull-build-default.yml
+++ b/.github/workflows/antsibull-build-default.yml
@@ -66,6 +66,6 @@ jobs:
         working-directory: antsibull
         run: |
           ansible-playbook -vv playbooks/build-single-release.yaml \
-          -e antsibull_build_command="poetry run antsibull-build" \
+          -e 'antsibull_build_command="poetry run antsibull-build"' \
           -e antsibull_data_reset=false \
           -e antsibull_ansible_version=5.99.0


### PR DESCRIPTION
There was a recent change in which the role no longer takes care of
installing antsibull so we need to install it before running the role.

See: https://github.com/ansible-community/antsibull/commit/d65f0c107ac6b3461864e383a049e903837df3ad