### PR TITLE
fixed typo in versioning information

### DIFF
--- a/5/CHANGELOG-v5.rst
+++ b/5/CHANGELOG-v5.rst
@@ -31,7 +31,7 @@ Added Collections
 Ansible-core
 ------------
 
-Ansible 5.9.0 contains Ansible-core version 2.12.0.
+Ansible 5.9.0 contains Ansible-core version 2.12.6.
 This is a newer version than version 2.12.5 contained in the previous Ansible release.
 
 Ansible-core did not have a changelog in this version.


### PR DESCRIPTION
Fixed typo

I think Ansible 5.9.0 uses ansible-core 2.12.6 and not 2.12.0