### PR TITLE
CI: Install missing build-release role dependency

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -76,6 +76,7 @@ jobs:
           python3 -m pip install poetry ansible-core
           poetry install
           poetry update
+          ansible-galaxy collection install 'git+https://github.com/ansible-collections/community.general.git'
 
       - name: Test building a release with the defaults
         working-directory: antsibull


### PR DESCRIPTION
As of
https://github.com/ansible-community/antsibull/commit/468273f7a28611062c84205e049211ec55b7bc92,
the antsibull build-release role depends on community.general.
Currently, CI jobs fail due to the missing dependency.