### PR TITLE
Add ibm.spectrum_virtualize to Ansible 6

### DIFF
--- a/6/ansible-6.build
+++ b/6/ansible-6.build
@@ -70,6 +70,7 @@ google.cloud: >=1.0.0,<2.0.0
 hetzner.hcloud: >=1.6.0,<2.0.0
 hpe.nimble: >=1.1.0,<2.0.0
 ibm.qradar: >=2.0.0,<3.0.0
+ibm.spectrum_virtualize: >=1.9.0,<2.0.0
 infinidat.infinibox: >=1.3.0,<2.0.0
 infoblox.nios_modules: >=1.2.0,<2.0.0
 inspur.sm: >=2.0.0,<3.0.0

--- a/6/ansible.in
+++ b/6/ansible.in
@@ -68,6 +68,7 @@ google.cloud
 hetzner.hcloud
 hpe.nimble
 ibm.qradar
+ibm.spectrum_virtualize
 infinidat.infinibox
 infoblox.nios_modules
 inspur.sm

--- a/6/collection-meta.yaml
+++ b/6/collection-meta.yaml
@@ -91,3 +91,6 @@ collections:
   purestorage.fusion:
     maintainers:
       - sdodsley
+  ibm.spectrum_virtualize:
+    maintainers:
+      - Shilpi-J

--- a/7/ansible.in
+++ b/7/ansible.in
@@ -68,6 +68,7 @@ google.cloud
 hetzner.hcloud
 hpe.nimble
 ibm.qradar
+ibm.spectrum_virtualize
 infinidat.infinibox
 infoblox.nios_modules
 inspur.sm

--- a/7/collection-meta.yaml
+++ b/7/collection-meta.yaml
@@ -91,3 +91,6 @@ collections:
   purestorage.fusion:
     maintainers:
       - sdodsley
+  ibm.spectrum_virtualize:
+    maintainers:
+      - Shilpi-J


### PR DESCRIPTION
Add ibm.spectrum_virtualize to Ansible 6
Relates to https://github.com/ansible-community/community-topics/issues/85