### PR TITLE
Deprecate google.cloud

### DIFF
--- a/6/changelog.yaml
+++ b/6/changelog.yaml
@@ -90,7 +90,7 @@ releases:
     changes:
       deprecated_features:
       - The google.cloud collection is considered unmaintained and will be
-        removed from Ansible 8 if nobody starts maintaining it again until then.
+        removed from Ansible 8 if no one starts maintaining it again before Ansible 8.
         See `the removal process for details on how this works
         <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
         (https://github.com/ansible-community/community-topics/issues/105).

--- a/6/changelog.yaml
+++ b/6/changelog.yaml
@@ -90,5 +90,5 @@ releases:
     changes:
       deprecated_features:
       - The google.cloud collection is considered unmaintained and will be
-        removed from Ansible 8.
+        removed from Ansible 8
         (https://github.com/ansible-community/community-topics/issues/105).

--- a/6/changelog.yaml
+++ b/6/changelog.yaml
@@ -86,3 +86,9 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2022-08-02'
+  6.3.0:
+    changes:
+      deprecated_features:
+      - The google.cloud collection is considered unmaintained and will be
+        removed from Ansible 8.
+        (https://github.com/ansible-community/community-topics/issues/105).

--- a/6/changelog.yaml
+++ b/6/changelog.yaml
@@ -90,5 +90,7 @@ releases:
     changes:
       deprecated_features:
       - The google.cloud collection is considered unmaintained and will be
-        removed from Ansible 8 if nobody starts maintaining it again until then
+        removed from Ansible 8 if nobody starts maintaining it again until then.
+        See `the removal process for details on how this works
+        <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
         (https://github.com/ansible-community/community-topics/issues/105).

--- a/6/changelog.yaml
+++ b/6/changelog.yaml
@@ -90,5 +90,5 @@ releases:
     changes:
       deprecated_features:
       - The google.cloud collection is considered unmaintained and will be
-        removed from Ansible 8
+        removed from Ansible 8 if nobody starts maintaining it again until then
         (https://github.com/ansible-community/community-topics/issues/105).


### PR DESCRIPTION
Deprecate `google.cloud` as discussed in ansible-community/community-topics#105 and voted on in ansible-community/community-topics#121