### PR TITLE
Also announce google.cloud removal in Ansible 7 changelog

### DIFF
--- a/7/changelog.yaml
+++ b/7/changelog.yaml
@@ -1,2 +1,10 @@
 ancestor: 6.0.0
-releases: {}
+releases:
+  7.0.0a1:
+    changes:
+      deprecated_features:
+      - The google.cloud collection is considered unmaintained and will be
+        removed from Ansible 8 if no one starts maintaining it again before Ansible 8.
+        See `the removal process for details on how this works
+        <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+        (https://github.com/ansible-community/community-topics/issues/105).


### PR DESCRIPTION
Follow-up to #150.

CC @mariolenz 