### PR TITLE
Announce removal of servicenow.servicenow in Ansible 7

### DIFF
--- a/6/changelog.yaml
+++ b/6/changelog.yaml
@@ -94,3 +94,8 @@ releases:
         See `the removal process for details on how this works
         <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
         (https://github.com/ansible-community/community-topics/issues/105).
+      - The servicenow.servicenow collection has been deprecated by its maintainers (ServiceNowITOM/servicenow-ansible#69)
+        and will be removed from Ansible 7 if no one starts maintaining it again before Ansible 7.
+        See `the removal process for details on how this works
+        <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+        (https://github.com/ansible-community/community-topics/issues/124).

--- a/6/changelog.yaml
+++ b/6/changelog.yaml
@@ -95,7 +95,6 @@ releases:
         <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
         (https://github.com/ansible-community/community-topics/issues/105).
       - The servicenow.servicenow collection has been deprecated by its maintainers (https://github.com/ServiceNowITOM/servicenow-ansible/pull/69)
-        and will be removed from Ansible 7 if no one starts maintaining it again before Ansible 7.
-        See `the removal process for details on how this works
-        <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+        and will be removed from Ansible 7. It can still be installed manually, but it is suggested
+        to swich to `servicenow.itsm <https://galaxy.ansible.com/servicenow/itsm>`__ instead
         (https://github.com/ansible-community/community-topics/issues/124).

--- a/6/changelog.yaml
+++ b/6/changelog.yaml
@@ -94,7 +94,7 @@ releases:
         See `the removal process for details on how this works
         <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
         (https://github.com/ansible-community/community-topics/issues/105).
-      - The servicenow.servicenow collection has been deprecated by its maintainers (ServiceNowITOM/servicenow-ansible#69)
+      - The servicenow.servicenow collection has been deprecated by its maintainers (https://github.com/ServiceNowITOM/servicenow-ansible/pull/69)
         and will be removed from Ansible 7 if no one starts maintaining it again before Ansible 7.
         See `the removal process for details on how this works
         <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__

--- a/7/ansible.in
+++ b/7/ansible.in
@@ -94,7 +94,6 @@ purestorage.flasharray
 purestorage.flashblade
 purestorage.fusion
 sensu.sensu_go
-servicenow.servicenow
 splunk.es
 theforeman.foreman
 t_systems_mms.icinga_director


### PR DESCRIPTION
Since `servicenow.servicenow` has been deprecated by its maintainers (ServiceNowITOM/servicenow-ansible#69), we should remove it from Ansible 7 and not do the complete [Unmaintained collections](https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections) process and wait until Ansible 8.

Fixes #144 