### PR TITLE
Deprecate dellemc.os6 / 9 / 10

### DIFF
--- a/6/changelog.yaml
+++ b/6/changelog.yaml
@@ -110,3 +110,18 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2022-09-15'
+  6.5.0:
+    changes:
+      deprecated_features:
+      - The dellemc.os6 collection is considered unmaintained and will be removed
+        from Ansible 8 if no one starts maintaining it again before Ansible 8. See
+        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+        (https://github.com/ansible-community/community-topics/issues/132).
+      - The dellemc.os9 collection is considered unmaintained and will be removed
+        from Ansible 8 if no one starts maintaining it again before Ansible 8. See
+        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+        (https://github.com/ansible-community/community-topics/issues/133).
+      - The dellemc.os10 collection is considered unmaintained and will be removed
+        from Ansible 8 if no one starts maintaining it again before Ansible 8. See
+        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+        (https://github.com/ansible-community/community-topics/issues/134).

--- a/7/changelog.yaml
+++ b/7/changelog.yaml
@@ -14,3 +14,18 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2022-09-29'
+  7.0.0a2:
+    changes:
+      deprecated_features:
+      - The dellemc.os6 collection is considered unmaintained and will be removed
+        from Ansible 8 if no one starts maintaining it again before Ansible 8. See
+        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+        (https://github.com/ansible-community/community-topics/issues/132).
+      - The dellemc.os9 collection is considered unmaintained and will be removed
+        from Ansible 8 if no one starts maintaining it again before Ansible 8. See
+        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+        (https://github.com/ansible-community/community-topics/issues/133).
+      - The dellemc.os10 collection is considered unmaintained and will be removed
+        from Ansible 8 if no one starts maintaining it again before Ansible 8. See
+        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+        (https://github.com/ansible-community/community-topics/issues/134).


### PR DESCRIPTION
Deprecate `dellemc.os6` / `9` / `10` as discussed in

- ansible-community/community-topics#132
- ansible-community/community-topics#133
- ansible-community/community-topics#134

and voted on in

- ansible-community/community-topics#139
- ansible-community/community-topics#140
- ansible-community/community-topics#141