### PR TITLE
Store collections' repository URLs in collection-meta.yaml

### DIFF
--- a/7/collection-meta.yaml
+++ b/7/collection-meta.yaml
@@ -5,102 +5,284 @@ collections:
       - cidrblock
       - ganeshrn
       - pabelanger
+    repository: https://github.com/ansible-collections/ansible.utils
   community.sops:
     maintainers:
       - endorama
+    repository: https://github.com/ansible-collections/community.sops
   cyberark.conjur:
     changelog-url: https://github.com/cyberark/ansible-conjur-collection/blob/master/CHANGELOG.md
+    repository: https://github.com/cyberark/ansible-conjur-collection
   dellemc.openmanage:
     changelog-url: https://github.com/dell/dellemc-openmanage-ansible-modules/blob/collections/CHANGELOG.rst
     maintainers:
       - rajeevarakkal
+    repository: https://github.com/dell/dellemc-openmanage-ansible-modules
   inspur.ispim:
     maintainers:
       - ispim
+    repository: https://github.com/ispim/inspur.ispim
   inspur.sm:
     maintainers:
       - ISIB-Group
+    repository: https://github.com/ISIB-Group/inspur.sm
   kubernetes.core:
     maintainers:
       - jillr
       - akasurde
       - gravesm
+    repository: https://github.com/ansible-collections/kubernetes.core
   sensu.sensu_go:
     maintainers:
       - tadeboro
       - mancabizjak
+    repository: https://github.com/sensu/sensu-go-ansible
   t_systems_mms.icinga_director:
     changelog-url: https://github.com/T-Systems-MMS/ansible-collection-icinga-director/blob/master/CHANGELOG.md
     maintainers:
       - rndmh3ro
       - schurzi
+    repository: https://github.com/T-Systems-MMS/ansible-collection-icinga-director
   dellemc.enterprise_sonic:
     maintainers:
       - javeedf
+    repository: https://github.com/ansible-collections/dellemc.enterprise_sonic
   hpe.nimble:
     maintainers:
       - ar-india
       - datamattsson
+    repository: https://github.com/hpe-storage/nimble-ansible-modules
   netapp.azure:
     maintainers:
       - carchi8py
       - lonico
+    repository: https://github.com/ansible-collections/netapp.azure
   netapp.cloudmanager:
     maintainers:
       - carchi8py
       - lonico
+    repository: https://github.com/ansible-collections/netapp.cloudmanager
   netapp.um_info:
     maintainers:
       - carchi8py
       - lonico
+    repository: https://github.com/ansible-collections/netapp.um_info
   community.ciscosmb:
     maintainers:
       - qaxi
+    repository: https://github.com/ansible-collections/community.ciscosmb
   community.dns:
     maintainers:
       - felixfontein
+    repository: https://github.com/ansible-collections/community.dns
   cloud.common:
     maintainers:
       - Akasurde
       - abikouo
       - goneri
       - jillr
+    repository: https://github.com/ansible-collections/cloud.common
   infoblox.nios_modules:
     maintainers:
       - anagha-infoblox
+    repository: https://github.com/infobloxopen/infoblox-ansible
   netapp.storagegrid:
     maintainers:
       - carchi8py
       - jkandati
       - joshedmonds
+    repository: https://github.com/ansible-collections/netapp.storagegrid
   cisco.ise:
     maintainers:
       - wastorga
       - racampos
       - jbogarin
+    repository: https://github.com/CiscoISE/ansible-ise
   community.sap:
     maintainers:
       - rainerleber
+    repository: https://github.com/ansible-collections/community.sap
   community.sap_libs:
     maintainers:
       - rainerleber
+    repository: https://github.com/sap-linuxlab/community.sap_libs
   vmware.vmware_rest:
     maintainers:
       - goneri
+    repository: https://github.com/ansible-collections/vmware.vmware_rest
   cisco.dnac:
     maintainers:
       - racampos
       - wastorga
+    repository: https://github.com/cisco-en-programmability/dnacenter-ansible
   purestorage.fusion:
     maintainers:
       - sdodsley
+    repository: https://github.com/Pure-Storage-Ansible/Fusion-Collection
   ibm.spectrum_virtualize:
     maintainers:
       - Shilpi-J
+    repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
   vultr.cloud:
     maintainers:
       - resmo
       - optik-aper
+    repository: https://github.com/vultr/ansible-collection-vultr
   lowlydba.sqlserver:
     maintainers:
       - lowlydba
+    repository: https://github.com/LowlyDBA/lowlydba.sqlserver
+  amazon.aws:
+    repository: https://github.com/ansible-collections/amazon.aws
+  ansible.netcommon:
+    repository: https://github.com/ansible-collections/ansible.netcommon
+  ansible.posix:
+    repository: https://github.com/ansible-collections/ansible.posix
+  ansible.windows:
+    repository: https://github.com/ansible-collections/ansible.windows
+  arista.eos:
+    repository: https://github.com/ansible-collections/arista.eos
+  awx.awx:
+    repository: https://github.com/ansible/awx
+  azure.azcollection:
+    repository: https://github.com/ansible-collections/azure
+  check_point.mgmt:
+    repository: https://github.com/CheckPointSW/CheckPointAnsibleMgmtCollection
+  chocolatey.chocolatey:
+    repository: https://github.com/chocolatey/chocolatey-ansible
+  cisco.aci:
+    repository: https://github.com/CiscoDevNet/ansible-aci
+  cisco.asa:
+    repository: https://github.com/ansible-collections/cisco.asa
+  cisco.intersight:
+    repository: https://github.com/CiscoDevNet/intersight-ansible
+  cisco.ios:
+    repository: https://github.com/ansible-collections/cisco.ios
+  cisco.iosxr:
+    repository: https://github.com/ansible-collections/cisco.iosxr
+  cisco.meraki:
+    repository: https://github.com/CiscoDevNet/ansible-meraki
+  cisco.mso:
+    repository: https://github.com/CiscoDevNet/ansible-mso
+  cisco.nso:
+    repository: https://github.com/CiscoDevNet/ansible-nso
+  cisco.nxos:
+    repository: https://github.com/ansible-collections/cisco.nxos
+  cisco.ucs:
+    repository: https://github.com/CiscoDevNet/ansible-ucs
+  cloudscale_ch.cloud:
+    repository: https://github.com/cloudscale-ch/ansible-collection-cloudscale
+  community.aws:
+    repository: https://github.com/ansible-collections/community.aws
+  community.azure:
+    repository: https://github.com/ansible-collections/community.azure
+  community.crypto:
+    repository: https://github.com/ansible-collections/community.crypto
+  community.digitalocean:
+    repository: https://github.com/ansible-collections/community.digitalocean
+  community.docker:
+    repository: https://github.com/ansible-collections/community.docker
+  community.fortios:
+    repository: https://github.com/ansible-collections/community.fortios
+  community.general:
+    repository: https://github.com/ansible-collections/community.general
+  community.google:
+    repository: https://github.com/ansible-collections/community.google
+  community.grafana:
+    repository: https://github.com/ansible-collections/grafana
+  community.hashi_vault:
+    repository: https://github.com/ansible-collections/community.hashi_vault
+  community.hrobot:
+    repository: https://github.com/ansible-collections/community.hrobot
+  community.libvirt:
+    repository: https://github.com/ansible-collections/community.libvirt
+  community.mongodb:
+    repository: https://github.com/ansible-collections/community.mongodb
+  community.mysql:
+    repository: https://github.com/ansible-collections/community.mysql
+  community.network:
+    repository: https://github.com/ansible-collections/community.network
+  community.okd:
+    repository: https://github.com/openshift/community.okd
+  community.postgresql:
+    repository: https://github.com/ansible-collections/community.postgresql
+  community.proxysql:
+    repository: https://github.com/ansible-collections/community.proxysql
+  community.rabbitmq:
+    repository: https://github.com/ansible-collections/community.rabbitmq
+  community.routeros:
+    repository: https://github.com/ansible-collections/community.routeros
+  community.skydive:
+    repository: https://github.com/ansible-collections/skydive
+  community.vmware:
+    repository: https://github.com/ansible-collections/community.vmware
+  community.windows:
+    repository: https://github.com/ansible-collections/community.windows
+  community.zabbix:
+    repository: https://github.com/ansible-collections/community.zabbix
+  containers.podman:
+    repository: https://github.com/containers/ansible-podman-collections
+  cyberark.pas:
+    repository: https://github.com/cyberark/ansible-security-automation-collection
+  dellemc.os10:
+    repository: https://github.com/ansible-collections/dellemc.os10
+  dellemc.os6:
+    repository: https://github.com/ansible-collections/dellemc.os6
+  dellemc.os9:
+    repository: https://github.com/ansible-collections/dellemc.os9
+  f5networks.f5_modules:
+    repository: https://github.com/F5Networks/f5-ansible
+  fortinet.fortimanager:
+    repository: https://github.com/fortinet-ansible-dev/ansible-galaxy-fortimanager-collection
+  fortinet.fortios:
+    repository: https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection
+  frr.frr:
+    repository: https://github.com/ansible-collections/frr.frr
+  gluster.gluster:
+    repository: https://github.com/gluster/gluster-ansible-collection
+  google.cloud:
+    repository: https://github.com/ansible/ansible_collections_google
+  hetzner.hcloud:
+    repository: https://github.com/ansible-collections/hetzner.hcloud
+  ibm.qradar:
+    repository: https://github.com/ansible-collections/ibm.qradar
+  infinidat.infinibox:
+    repository: https://github.com/infinidat/ansible-infinidat-collection
+  junipernetworks.junos:
+    repository: https://github.com/ansible-collections/junipernetworks.junos
+  mellanox.onyx:
+    repository: https://github.com/ansible-collections/mellanox.onyx
+  netapp.aws:
+    repository: https://github.com/ansible-collections/netapp.aws
+  netapp.elementsw:
+    repository: https://github.com/ansible-collections/netapp.elementsw
+  netapp.ontap:
+    repository: https://github.com/ansible-collections/netapp.ontap
+  netapp_eseries.santricity:
+    repository: https://github.com/netapp-eseries/santricity
+  netbox.netbox:
+    repository: https://github.com/netbox-community/ansible_modules
+  ngine_io.cloudstack:
+    repository: https://github.com/ngine-io/ansible-collection-cloudstack
+  ngine_io.exoscale:
+    repository: https://github.com/ngine-io/ansible-collection-exoscale
+  ngine_io.vultr:
+    repository: https://github.com/ngine-io/ansible-collection-vultr
+  openstack.cloud:
+    repository: https://opendev.org/openstack/ansible-collections-openstack
+  openvswitch.openvswitch:
+    repository: https://github.com/ansible-collections/openvswitch.openvswitch
+  ovirt.ovirt:
+    repository: https://github.com/ovirt/ovirt-ansible-collection
+  purestorage.flasharray:
+    repository: https://github.com/Pure-Storage-Ansible/FlashArray-Collection
+  purestorage.flashblade:
+    repository: https://github.com/Pure-Storage-Ansible/FlashBlade-Collection
+  splunk.es:
+    repository: https://github.com/ansible-collections/splunk.es
+  theforeman.foreman:
+    repository: https://github.com/theforeman/foreman-ansible-modules
+  vyos.vyos:
+    repository: https://github.com/ansible-collections/vyos.vyos
+  wti.remote:
+    repository: https://github.com/wtinetworkgear/wti-collection

--- a/7/collection-meta.yaml
+++ b/7/collection-meta.yaml
@@ -144,6 +144,7 @@ collections:
     repository: https://github.com/ansible-collections/arista.eos
   awx.awx:
     repository: https://github.com/ansible/awx
+    collection-directory: "./awx_collection"
   azure.azcollection:
     repository: https://github.com/ansible-collections/azure
   check_point.mgmt:
@@ -286,3 +287,4 @@ collections:
     repository: https://github.com/ansible-collections/vyos.vyos
   wti.remote:
     repository: https://github.com/wtinetworkgear/wti-collection
+    collection-directory: "./wti/remote"

--- a/README.md
+++ b/README.md
@@ -49,10 +49,44 @@ Release engineers check the [milestones](https://github.com/ansible-community/an
 
 To add a collection to the next Ansible major release that has not reached feature freeze:
 
-* Add the collection to the `ansible.in` file in a sub-directory named with a corresponding number.
-* In the same sub-directory, add the collection to the `collection-meta.yaml` file.
-  - The maintainer's GitHub user names need to be listed there.
-  - If the collection does not provide a changelog in `changelogs/changelog.yaml`, the URL to the actual changelog needs to be added.
+* Add the collection to the `ansible.in` file in a sub-directory named with a
+  corresponding number.
+* In the same sub-directory, add the collection to the `collection-meta.yaml`
+  file, as shown below.
+  - `maintainers` (list): The Github usernames of the collection's maintainers.
+  - `repository` (string): The URL of the collection's git repository.
+  - `collection-directory` (string): The collection's top level directory
+    relative to the Git repository root. The top level directory is where
+    `galaxy.yml` is located. For most collections, this should be set to `.`.
+    However, some collections, such as `awx.awx`, store the collection in a
+    subdirectory. In that case, `collection-directory` should be set to
+    `./SUBDIRECTORY` (`SUBDIRECTORY` is a placeholder for the actual
+    directory).
+  - `changelog-url` (string): If the collection does not provide a changelog in
+    `changelogs/changelog.yaml`, the URL to the actual changelog needs to be
+    added. Otherwise, this field should be ommitted.
+
+``` yaml
+collections:
+  # NAMESPACE.NAME
+  community.example:
+    # The Github usernames of this collection's maintainers
+    maintainers:
+      - person1
+      - person2
+    # The URL to the collection's SCM repository.
+    repository: https://github.com/ansible-collections/community.example
+    # This is the directory where galaxy.yml is stored relative to the
+    # repository root.
+    #
+    # For collections stored in the repository root:
+    collection-directory: "."
+    # For collections stored in a subdirectory:
+    collection-directory: "./SUBDIRECTORY"
+    # This is an optional field that should only be populated if the
+    # doesn't include a changelogs/changelog.yaml file.
+    # changelog-url: ...
+```
 
 ### The current Ansible major release
 


### PR DESCRIPTION
In https://github.com/ansible-community/community-topics/issues/148, we discussed implementing a check to make sure that collections in the Ansible package actually tag releases. Having a list of the collections' repository URLs is a necessary prerequisite. This will also allow for other possibilities in the future if we decide to implement other checks or build process changes or something else! In addition to the `repository` field, I added a `collection-directory` field so we can account for collections that are located in a subdirectory of their respective repository.

I added documentation for these new changes and reformatted the existing documentation. I chose `collection-directory` and `repository` as the field names, but I'm open to suggestions.