### PR TITLE
Deprecate community.google + community.skydive

### DIFF
--- a/7/changelog.yaml
+++ b/7/changelog.yaml
@@ -77,3 +77,11 @@ releases:
           from Ansible 9 if no one starts maintaining it again before Ansible 9. See
           `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
           (https://github.com/ansible-community/community-topics/issues/162).
+        - The community.google collection is considered unmaintained and will be removed
+          from Ansible 9 if no one starts maintaining it again before Ansible 9. See
+          `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+          (https://github.com/ansible-community/community-topics/issues/160).
+        - The community.skydive collection is considered unmaintained and will be removed
+          from Ansible 9 if no one starts maintaining it again before Ansible 9. See
+          `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+          (https://github.com/ansible-community/community-topics/issues/171).

--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -27,3 +27,11 @@ releases:
           from Ansible 9 if no one starts maintaining it again before Ansible 9. See
           `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
           (https://github.com/ansible-community/community-topics/issues/162).
+        - The community.google collection is considered unmaintained and will be removed
+          from Ansible 9 if no one starts maintaining it again before Ansible 9. See
+          `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+          (https://github.com/ansible-community/community-topics/issues/160).
+        - The community.skydive collection is considered unmaintained and will be removed
+          from Ansible 9 if no one starts maintaining it again before Ansible 9. See
+          `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+          (https://github.com/ansible-community/community-topics/issues/171).


### PR DESCRIPTION
Deprecate

1. community.google as discussed in ansible-community/community-topics#160 and voted on in ansible-community/community-topics#181
2. community.skydive as discussed in ansible-community/community-topics#171 and voted on in ansible-community/community-topics#182