### PR TITLE
Re-add google.cloud to Ansible 8

### DIFF
--- a/7/changelog.yaml
+++ b/7/changelog.yaml
@@ -90,3 +90,10 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2023-01-31'
+  7.3.0:
+    changes:
+      deprecated_features:
+      - Since the google.cloud collection seems to be maintained again, we
+        `cancelled the removal process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__.
+        So contrary to an earlier announcement, this collection is NOT deprecated and will NOT be removed from Ansible 8
+        (https://github.com/ansible-community/community-topics/issues/105).

--- a/8/ansible.in
+++ b/8/ansible.in
@@ -63,6 +63,7 @@ fortinet.fortimanager
 fortinet.fortios
 frr.frr
 gluster.gluster
+google.cloud
 grafana.grafana
 hetzner.hcloud
 hpe.nimble

--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -3,9 +3,6 @@ releases:
   8.0.0a1:
     changes:
       removed_features:
-        - "``google.cloud`` was considered unmaintained and removed from Ansible 8 as per the
-          `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_.
-          Users can still install this collection with ``ansible-galaxy collection install google.cloud``."
         - "``mellanox.onyx`` was considered unmaintained and removed from Ansible 8 as per the
           `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_.
           Users can still install this collection with ``ansible-galaxy collection install mellanox.onyx``."

--- a/8/collection-meta.yaml
+++ b/8/collection-meta.yaml
@@ -261,6 +261,8 @@ collections:
     repository: https://github.com/ansible-collections/frr.frr
   gluster.gluster:
     repository: https://github.com/gluster/gluster-ansible-collection
+  google.cloud:
+    repository: https://github.com/ansible-collections/google.cloud
   hetzner.hcloud:
     repository: https://github.com/ansible-collections/hetzner.hcloud
   ibm.qradar:


### PR DESCRIPTION
Keep `google.cloud` in Ansible 8 as discussed in ansible-community/community-topics#105 and voted on in ansible-community/community-topics#195.