### PR TITLE
CI: use `pip` instead of `poetry install` (take 2)

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -44,13 +44,6 @@ jobs:
           ref: main
           path: antsibull-changelog
 
-      - name: Check out antsibull-docs
-        uses: actions/checkout@v3
-        with:
-          repository: ansible-community/antsibull-docs
-          ref: main
-          path: antsibull-docs
-
       - name: Pre-create build directory
         run: mkdir -p antsibull/build
 
@@ -69,7 +62,7 @@ jobs:
         working-directory: antsibull
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install ansible-core . ../antsibull-changelog ../antsibull-docs
+          python3 -m pip install ansible-core . ../antsibull-core ../antsibull-changelog
           ansible-galaxy collection install 'git+https://github.com/ansible-collections/community.general.git'
 
       - name: Test building a release with the defaults


### PR DESCRIPTION
antsibull-core needs to be installed from the local checkout, and
antsibull-docs is no longer a dependency of antsibull.

Fixes: 303c42f966fc0ae805f2421a04a831c42a1a6462
