### PR TITLE
add validate-tags-ignores files

### DIFF
--- a/7/validate-tags-ignores
+++ b/7/validate-tags-ignores
@@ -1,0 +1,8 @@
+# https://github.com/ansible-community/ansible-build-data/issues/190
+# This will be removed in Ansible 9
+cisco.nso
+# https://github.com/hpe-storage/nimble-ansible-modules/issues/59
+# Awaiting response from the maintainer
+hpe.nimble
+# This has been removed in Ansible 8
+mellanox.onyx

--- a/8/validate-tags-ignores
+++ b/8/validate-tags-ignores
@@ -1,0 +1,6 @@
+# https://github.com/ansible-community/ansible-build-data/issues/190
+# This will be removed in Ansible 9
+cisco.nso
+# https://github.com/hpe-storage/nimble-ansible-modules/issues/59
+# Awaiting response from the maintainer
+hpe.nimble


### PR DESCRIPTION
These are ignores files for the new collection tag policy enforcement proposal. These files silence release tag validation errors for the listed collection. Currently, those validation errors are treated as warnings.

I will also add docs for this.

Depends-on: https://github.com/ansible-community/antsibull/pull/518