### PR TITLE
8: pin dellemc.enterprise_sonic to 2.0.0

### DIFF
--- a/8/ansible-8.build
+++ b/8/ansible-8.build
@@ -57,7 +57,9 @@ community.zabbix: >=2.0.0,<3.0.0
 containers.podman: >=1.10.0,<2.0.0
 cyberark.conjur: >=1.2.0,<2.0.0
 cyberark.pas: >=1.0.0,<2.0.0
-dellemc.enterprise_sonic: >=2.0.0,<3.0.0
+# 2.1.0 has depclosure errors
+# https://github.com/ansible-community/ansible-build-data/issues/233
+dellemc.enterprise_sonic: ==2.0.0
 dellemc.openmanage: >=7.5.0,<8.0.0
 dellemc.powerflex: >=1.6.0,<2.0.0
 dellemc.unity: >=1.6.0,<2.0.0


### PR DESCRIPTION
dellemc.enterprise_sonic has depclosure errors. This pins it to the last
working version. Normally, we wouldn't use ==, but since 2.0.0 is the
only release in the range.

```
ERROR: found collection dependency
ERROR: dellemc.enterprise_sonic version_conflict: ansible.netcommon-5.1.1 but needs >=2.0.0,<5.0.0
```

Relates: https://github.com/ansible-community/ansible-build-data/issues/233
Relates: https://github.com/ansible-collections/dellemc.enterprise_sonic/issues/267
