### PR TITLE
Revert "Pin cyberark.pas due to tagging policy violations"

### DIFF
--- a/7/ansible-7.build
+++ b/7/ansible-7.build
@@ -56,7 +56,7 @@ community.windows: >=1.11.0,<2.0.0
 community.zabbix: >=1.8.0,<2.0.0
 containers.podman: >=1.9.0,<2.0.0
 cyberark.conjur: >=1.2.0,<2.0.0
-cyberark.pas: >=1.0.0,<=1.0.17
+cyberark.pas: >=1.0.0,<2.0.0
 dellemc.enterprise_sonic: >=2.0.0,<3.0.0
 dellemc.openmanage: >=6.3.0,<7.0.0
 dellemc.os10: >=1.1.0,<2.0.0

--- a/8/ansible-8.build
+++ b/8/ansible-8.build
@@ -56,7 +56,7 @@ community.windows: >=1.13.0,<2.0.0
 community.zabbix: >=2.0.0,<3.0.0
 containers.podman: >=1.10.0,<2.0.0
 cyberark.conjur: >=1.2.0,<2.0.0
-cyberark.pas: >=1.0.0,<=1.0.17
+cyberark.pas: >=1.0.0,<2.0.0
 # 2.1.0 has depclosure errors
 # https://github.com/ansible-community/ansible-build-data/issues/233
 dellemc.enterprise_sonic: ==2.0.0


### PR DESCRIPTION
This reverts commit 0592a32a90d803297748b9f323b9f487d5e007a9.

Closes: https://github.com/cyberark/ansible-security-automation-collection/issues/58