### PR TITLE
Deprecate netapp.aws

### DIFF
--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -69,3 +69,10 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2023-05-23'
+  8.0.0:
+    changes:
+      deprecated_features:
+        - The netapp.aws collection is considered unmaintained and will be removed
+          from Ansible 10 if no one starts maintaining it again before Ansible 10. See
+          `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+          (https://github.com/ansible-community/community-topics/issues/223).


### PR DESCRIPTION
Deprecate netapp.aws as discussed in ansible-community/community-topics#223 and voted on in ansible-community/community-topics#229