### PR TITLE
Ansible 8: allow dellemc.enterprise_sonic != 2.1.0

### DIFF
--- a/8/ansible-8.build
+++ b/8/ansible-8.build
@@ -57,9 +57,7 @@ community.zabbix: >=2.0.0,<3.0.0
 containers.podman: >=1.10.0,<2.0.0
 cyberark.conjur: >=1.2.0,<2.0.0
 cyberark.pas: >=1.0.0,<2.0.0
-# 2.1.0 has depclosure errors
-# https://github.com/ansible-community/ansible-build-data/issues/233
-dellemc.enterprise_sonic: ==2.0.0
+dellemc.enterprise_sonic: >=2.0.0,<3.0.0,!=2.1.0
 dellemc.openmanage: >=7.5.0,<8.0.0
 dellemc.powerflex: >=1.6.0,<2.0.0
 dellemc.unity: >=1.6.0,<2.0.0

--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -85,4 +85,4 @@ releases:
       - Please note that the breaking change announced in the dellemc.enterprise_sonic
         changelog below is from dellemc.enterprise_sonic 2.1.0 and was reverted in
         dellemc.enterprise_sonic 2.2.0, so it is not contained in Ansible 8.
-        For technical reasons this entry is still shown here.
+        For technical reasons, this entry is still shown here.

--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -79,3 +79,10 @@ releases:
       release_summary: 'Release Date: 2023-05-30
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2023-05-30'
+  8.1.0:
+    changes:
+      breaking_changes:
+      - Please note that the breaking change announced in the dellemc.enterprise_sonic
+        changelog below is from dellemc.enterprise_sonic 2.1.0 and was reverted in
+        dellemc.enterprise_sonic 2.2.0, so it is not contained in Ansible 8.
+        For technical reasons this entry is still shown here.


### PR DESCRIPTION
The breaking change in dellemc.enterprise_sonic has been reverted (see https://github.com/ansible-collections/dellemc.enterprise_sonic/issues/268), and the restriction to ansible.netcommon < 5.0.0 has been lifted (see https://github.com/ansible-community/ansible-build-data/issues/233). Therefore we remove the pin to 2.0.0 for Ansible 8.

Resolves https://github.com/ansible-collections/dellemc.enterprise_sonic/issues/267
Resolves https://github.com/ansible-collections/dellemc.enterprise_sonic/issues/268
Resolves https://github.com/ansible-community/ansible-build-data/issues/233