### PR TITLE
Deprecate netapp.aws in 7.7.0

### DIFF
--- a/7/changelog.yaml
+++ b/7/changelog.yaml
@@ -123,3 +123,10 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2023-05-23'
+  7.7.0:
+    changes:
+      deprecated_features:
+      - The netapp.aws collection is considered unmaintained and will be removed
+        from Ansible 10 if no one starts maintaining it again before Ansible 10. See
+        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+        (https://github.com/ansible-community/community-topics/issues/223).


### PR DESCRIPTION
I thought that 7.6.0 would be the last 7.x release, but since it looks like there will be a 7.7.0 we should mention the deprecation of netapp.aws there.

This is kind of a backport of #242 