### PR TITLE
Ansible 7: restrict dellemc.os10 to <= 1.1.1

### DIFF
--- a/7/ansible-7.build
+++ b/7/ansible-7.build
@@ -59,7 +59,7 @@ cyberark.conjur: >=1.2.0,<2.0.0
 cyberark.pas: >=1.0.0,<2.0.0
 dellemc.enterprise_sonic: ==2.0.0
 dellemc.openmanage: >=6.3.0,<7.0.0
-dellemc.os10: >=1.1.0,<2.0.0
+dellemc.os10: >=1.1.0,<=1.1.1
 dellemc.os6: >=1.0.0,<2.0.0
 dellemc.os9: >=1.0.0,<2.0.0
 dellemc.powerflex: >=1.5.0,<2.0.0


### PR DESCRIPTION
While Ansible 7 is EOL, it is still used in CI (for antsibull-core and antsibull). Now dellemc.os10 has a new release (it was already tagged in March, but only published on Galaxy yesterday) that restricts its ansible.netcommon dependency to < 4.0.0, which contradicts ansible.netcommon >= 4.0.0 in Ansible 7. This makes CI fail in the antsibull-core and antsibull repositories.

Ref: https://github.com/ansible-community/antsibull-core/actions/runs/5440478551/jobs/9893441001
Ref: https://github.com/ansible-community/antsibull/actions/runs/5440539601/jobs/9893565581
