### PR TITLE
replace t_systems_mms with telekom_mms

### DIFF
--- a/8/ansible-8.build
+++ b/8/ansible-8.build
@@ -102,6 +102,7 @@ sensu.sensu_go: >=1.13.0,<2.0.0
 servicenow.servicenow: >=1.0.0,<2.0.0
 splunk.es: >=2.1.0,<3.0.0
 t_systems_mms.icinga_director: >=1.32.0,<2.0.0
+telekom_mms.icinga_director: >=1.32.0,<2.0.0
 theforeman.foreman: >=3.10.0,<4.0.0
 vmware.vmware_rest: >=2.3.0,<3.0.0
 vultr.cloud: >=1.7.0,<2.0.0

--- a/8/ansible.in
+++ b/8/ansible.in
@@ -100,6 +100,7 @@ servicenow.servicenow
 splunk.es
 theforeman.foreman
 t_systems_mms.icinga_director
+telekom_mms.icinga_director
 vmware.vmware_rest
 vultr.cloud
 vyos.vyos

--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -118,3 +118,9 @@ releases:
         from Ansible 10 if no one starts maintaining it again before Ansible 10. See
         `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
         (https://github.com/ansible-community/community-topics/issues/234).
+      - The collection ``t_systems_mms.icinga_director`` has been renamed to ``telekom_mms.icinga_director``.
+        For now both collections are included in Ansible. The content in ``t_systems_mms.icinga_director``
+        will be replaced with deprecated redirects to the new collection in Ansible 9.0.0,
+        and these redirects will eventually be removed from Ansible. Please update your
+        FQCNs for ``t_systems_mms.icinga_director``.
+

--- a/8/collection-meta.yaml
+++ b/8/collection-meta.yaml
@@ -43,6 +43,12 @@ collections:
       - rndmh3ro
       - schurzi
     repository: https://github.com/T-Systems-MMS/ansible-collection-icinga-director
+  telekom_mms.icinga_director:
+    changelog-url: https://github.com/telekom-mms/ansible-collection-icinga-director/blob/master/CHANGELOG.md
+    maintainers:
+      - rndmh3ro
+      - schurzi
+    repository: https://github.com/telekom-mms/ansible-collection-icinga-director
   dellemc.enterprise_sonic:
     maintainers:
       - javeedf

--- a/9/ansible.in
+++ b/9/ansible.in
@@ -95,6 +95,7 @@ sensu.sensu_go
 splunk.es
 theforeman.foreman
 t_systems_mms.icinga_director
+telekom_mms.icinga_director
 vmware.vmware_rest
 vultr.cloud
 vyos.vyos

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -34,3 +34,9 @@ releases:
           from Ansible 10 if no one starts maintaining it again before Ansible 10. See
           `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
           (https://github.com/ansible-community/community-topics/issues/234).
+        - The collection ``t_systems_mms.icinga_director`` has been renamed to ``telekom_mms.icinga_director``.
+          For now both collections are included in Ansible. The content in ``t_systems_mms.icinga_director``
+          has been replaced with deprecated redirects to the new collection in Ansible 9.0.0,
+          and these redirects will be removed from Ansible 11. Please update your
+          FQCNs for ``t_systems_mms.icinga_director``.
+

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -43,6 +43,12 @@ collections:
       - rndmh3ro
       - schurzi
     repository: https://github.com/T-Systems-MMS/ansible-collection-icinga-director
+  telekom_mms.icinga_director:
+    changelog-url: https://github.com/telekom-mms/ansible-collection-icinga-director/blob/master/CHANGELOG.md
+    maintainers:
+      - rndmh3ro
+      - schurzi
+    repository: https://github.com/telekom-mms/ansible-collection-icinga-director
   dellemc.enterprise_sonic:
     maintainers:
       - javeedf


### PR DESCRIPTION
We renamed our company and thus the collection-namespace here: https://github.com/ansible/galaxy/issues/3174

The collection now lives here: https://github.com/telekom-mms/ansible-collection-icinga-director

I released a new major version 2.0.0 in the old namespace (https://galaxy.ansible.com/t_systems_mms/icinga_director) where I added the plugin-routing to the new namespace. I also deprecated the collection in the galaxy.

This way I hope in Ansible 8 the old collection will stay the same while in Ansible 9 the new collection will be used.