### PR TITLE
Deprecate community.sap (again)

### DIFF
--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -100,3 +100,8 @@ releases:
       deprecated_features:
       - The deprecated servicenow.servicenow collection has been removed from Ansible 7, but accidentally re-added to Ansible 8. It will be removed again from Ansible 9
         (https://github.com/ansible-community/community-topics/issues/246).
+      - The collection ``community.sap`` has been renamed to ``community.sap_libs``.
+        For now both collections are included in Ansible. The content in ``community.sap``
+        will be replaced with deprecated redirects to the new collection in Ansible 9.0.0,
+        and the collection will be removed from Ansible 10 completely. Please update your
+        FQCNs for ``community.sap``.

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -24,3 +24,9 @@ releases:
           Users can still install this collection with ``ansible-galaxy collection install community.skydive``."
         - The deprecated servicenow.servicenow collection has been removed from Ansible 7, but accidentally re-added to Ansible 8. It has been removed again from Ansible 9
           (https://github.com/ansible-community/community-topics/issues/246).
+      deprecated_features:
+        - The collection ``community.sap`` has been renamed to ``community.sap_libs``.
+          For now both collections are included in Ansible. The content in ``community.sap``
+          has deprecated redirects to the new collection in Ansible 9.0.0,
+          and the collection will be removed from Ansible 10 completely. Please update your
+          FQCNs for ``community.sap``.


### PR DESCRIPTION
`community.sap` has been renamed and there should have been deprecated redirects to the new collections. Somehow, this never happened. But now there is finally a new release implementing those redirects, so we should announce this again and remove the collection in Ansible 10.

See ansible-community/community-topics#247 for more information and links to the old discussions.