### PR TITLE
Ignore missing git tag for t_systems_mms.icinga_director

### DIFF
--- a/9/validate-tags-ignores
+++ b/9/validate-tags-ignores
@@ -1,0 +1,4 @@
+# https://github.com/ansible-community/ansible-build-data/pull/261
+# This collection is deprecated (namespace has been renamed) and
+# will be removed eventually.
+t_systems_mms.icinga_director


### PR DESCRIPTION
Currently CI is broken because t_systems_mms.icinga_director 2.0.0 is not tagged - the repository has been renamed.