### PR TITLE
9: remove no longer necessary ignore

### DIFF
--- a/9/validate-tags-ignores
+++ b/9/validate-tags-ignores
@@ -1,4 +1,0 @@
-# https://github.com/ansible-community/ansible-build-data/pull/261
-# This collection is deprecated (namespace has been renamed) and
-# will be removed eventually.
-t_systems_mms.icinga_director


### PR DESCRIPTION
Since the t_systems_mms.icinga_director 2.0.1 release the ignore is no longer necessary.

Ref: #261