### PR TITLE
9: add inspur.ispim to validate-tags-ignore

### DIFF
--- a/9/validate-tags-ignores
+++ b/9/validate-tags-ignores
@@ -1,0 +1,2 @@
+# https://github.com/ispim/inspur.ispim/issues/24
+inspur.ispim


### PR DESCRIPTION
We don't currently have a way to pin collection versions for prior to
X.Y.0a1, so we'll ignore it for now.

Relates: https://github.com/ispim/inspur.ispim/issues/24
