### PR TITLE
Remove ngine_io.vultr from Ansible 9

### DIFF
--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -127,3 +127,7 @@ releases:
         from Ansible 10 if no one starts maintaining it again before Ansible 10. See
         `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
         (https://github.com/ansible-community/community-topics/issues/235).
+      - The ngine_io.vultr collection is officially unmaintained and has been archived. Therefor, it will be removed from Ansible 9.
+        There is already a successor collection vultr.cloud (using the recent v2 Vultr API) in the community package which
+        covers the functionality but might not have compatible syntax
+        (https://github.com/ansible-community/community-topics/issues/257).

--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -127,7 +127,7 @@ releases:
         from Ansible 10 if no one starts maintaining it again before Ansible 10. See
         `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
         (https://github.com/ansible-community/community-topics/issues/235).
-      - The ngine_io.vultr collection is officially unmaintained and has been archived. Therefor, it will be removed from Ansible 9.
-        There is already a successor collection vultr.cloud (using the recent v2 Vultr API) in the community package which
+      - The ngine_io.vultr collection is officially unmaintained and has been archived. Therefore, it will be removed from Ansible 9.
+        There is already a successor collection ``vultr.cloud`` (using the recent v2 Vultr API) in the community package which
         covers the functionality but might not have compatible syntax
         (https://github.com/ansible-community/community-topics/issues/257).

--- a/9/ansible.in
+++ b/9/ansible.in
@@ -84,7 +84,6 @@ netapp.um_info
 netbox.netbox
 ngine_io.cloudstack
 ngine_io.exoscale
-ngine_io.vultr
 openstack.cloud
 openvswitch.openvswitch
 ovirt.ovirt

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -24,8 +24,8 @@ releases:
           Users can still install this collection with ``ansible-galaxy collection install community.skydive``."
         - The deprecated servicenow.servicenow collection has been removed from Ansible 7, but accidentally re-added to Ansible 8. It has been removed again from Ansible 9
           (https://github.com/ansible-community/community-topics/issues/246).
-        - The ngine_io.vultr collection has been removed from Ansible 9 because it is officially unmaintained and has been archived.
-          The successor collection vultr.cloud (using the recent v2 Vultr API) covers the same functionality but might not have compatible syntax.
+        - The ngine_io.vultr collection has been removed from Ansible 9, because it is officially unmaintained and has been archived.
+          The successor collection ``vultr.cloud`` (using the recent v2 Vultr API) covers the same functionality but might not have compatible syntax.
       deprecated_features:
         - The collection ``community.sap`` has been renamed to ``community.sap_libs``.
           For now both collections are included in Ansible. The content in ``community.sap``

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -24,6 +24,8 @@ releases:
           Users can still install this collection with ``ansible-galaxy collection install community.skydive``."
         - The deprecated servicenow.servicenow collection has been removed from Ansible 7, but accidentally re-added to Ansible 8. It has been removed again from Ansible 9
           (https://github.com/ansible-community/community-topics/issues/246).
+        - The ngine_io.vultr collection has been removed from Ansible 9 because it is officially unmaintained and has been archived.
+          The successor collection vultr.cloud (using the recent v2 Vultr API) covers the same functionality but might not have compatible syntax.
       deprecated_features:
         - The collection ``community.sap`` has been renamed to ``community.sap_libs``.
           For now both collections are included in Ansible. The content in ``community.sap``

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -25,7 +25,8 @@ releases:
         - The deprecated servicenow.servicenow collection has been removed from Ansible 7, but accidentally re-added to Ansible 8. It has been removed again from Ansible 9
           (https://github.com/ansible-community/community-topics/issues/246).
         - The ngine_io.vultr collection has been removed from Ansible 9, because it is officially unmaintained and has been archived.
-          The successor collection ``vultr.cloud`` (using the recent v2 Vultr API) covers the same functionality but might not have compatible syntax.
+          The successor collection ``vultr.cloud`` (using the recent v2 Vultr API) covers the same functionality but might not have compatible syntax
+          (https://github.com/ansible-community/community-topics/issues/257).
       deprecated_features:
         - The collection ``community.sap`` has been renamed to ``community.sap_libs``.
           For now both collections are included in Ansible. The content in ``community.sap``

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -287,8 +287,6 @@ collections:
     repository: https://github.com/ngine-io/ansible-collection-cloudstack
   ngine_io.exoscale:
     repository: https://github.com/ngine-io/ansible-collection-exoscale
-  ngine_io.vultr:
-    repository: https://github.com/ngine-io/ansible-collection-vultr
   openstack.cloud:
     repository: https://opendev.org/openstack/ansible-collections-openstack
   openvswitch.openvswitch:


### PR DESCRIPTION
Deprecate ngine_io.vultr and remove it from Ansible 9 as discussed in ansible-community/community-topics#257 and voted on in ansible-community/community-topics#259