### PR TITLE
Deprecate hpe.nimble

### DIFF
--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -149,3 +149,7 @@ releases:
         collection ``azure.azcollection`` in the community package which should cover
         the same functionality
         (https://github.com/ansible-community/community-topics/issues/263).
+      - The ``hpe.nimble`` collection is considered unmaintained and will be removed
+        from Ansible 10 if no one starts maintaining it again before Ansible 10. See
+        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+        (https://github.com/ansible-community/community-topics/issues/254).

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -55,3 +55,7 @@ releases:
           collection ``azure.azcollection`` in the community package which should cover
           the same functionality
           (https://github.com/ansible-community/community-topics/issues/263).
+        - The ``hpe.nimble`` collection is considered unmaintained and will be removed
+          from Ansible 10 if no one starts maintaining it again before Ansible 10. See
+          `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
+          (https://github.com/ansible-community/community-topics/issues/254).


### PR DESCRIPTION
Deprecate hpe.nimble as discussed in ansible-community/community-topics#254 and voted on in ansible-community/community-topics#265.