### PR TITLE
Add ibm.storage_virtualize, which ibm.spectrum_virtualize was renamed to

### DIFF
--- a/8/ansible-8.build
+++ b/8/ansible-8.build
@@ -72,6 +72,7 @@ hetzner.hcloud: >=1.11.0,<2.0.0,!=1.12.0,!=1.13.0,!=1.14.0,!=1.15.0
 hpe.nimble: >=1.1.0,<2.0.0
 ibm.qradar: >=2.1.0,<3.0.0
 ibm.spectrum_virtualize: >=1.12.0,<2.0.0
+ibm.storage_virtualize: >=2.1.0,<3.0.0
 infinidat.infinibox: >=1.3.0,<2.0.0
 infoblox.nios_modules: >=1.5.0,<2.0.0
 inspur.ispim: >=1.3.0,<2.0.0

--- a/8/ansible.in
+++ b/8/ansible.in
@@ -69,6 +69,7 @@ hetzner.hcloud
 hpe.nimble
 ibm.qradar
 ibm.spectrum_virtualize
+ibm.storage_virtualize
 infinidat.infinibox
 infoblox.nios_modules
 inspur.ispim

--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -164,3 +164,11 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2023-10-11'
+  8.6.0:
+    changes:
+      deprecated_features:
+      - The collection ``ibm.spectrum_virtualize`` has been renamed to ``ibm.storage_virtualize``.
+        For now both collections are included in Ansible. The content in ``ibm.spectrum_virtualize``
+        will be replaced with deprecated redirects to the new collection in Ansible 10.0.0,
+        and these redirects will eventually be removed from Ansible. Please update your
+        FQCNs for ``ibm.spectrum_virtualize``.

--- a/8/changelog.yaml
+++ b/8/changelog.yaml
@@ -168,7 +168,7 @@ releases:
     changes:
       deprecated_features:
       - The collection ``ibm.spectrum_virtualize`` has been renamed to ``ibm.storage_virtualize``.
-        For now both collections are included in Ansible. The content in ``ibm.spectrum_virtualize``
+        For now, both collections are included in Ansible. The content in ``ibm.spectrum_virtualize``
         will be replaced with deprecated redirects to the new collection in Ansible 10.0.0,
         and these redirects will eventually be removed from Ansible. Please update your
         FQCNs for ``ibm.spectrum_virtualize``.

--- a/8/collection-meta.yaml
+++ b/8/collection-meta.yaml
@@ -136,7 +136,7 @@ collections:
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
   ibm.storage_virtualize:
     maintainers:
-      - Shilpi-J
+      - sumitguptaibm
     repository: https://github.com/ansible-collections/ibm.storage_virtualize
   vultr.cloud:
     maintainers:

--- a/8/collection-meta.yaml
+++ b/8/collection-meta.yaml
@@ -134,6 +134,10 @@ collections:
     maintainers:
       - Shilpi-J
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
+  ibm.storage_virtualize:
+    maintainers:
+      - Shilpi-J
+    repository: https://github.com/ansible-collections/ibm.storage_virtualize
   vultr.cloud:
     maintainers:
       - resmo

--- a/9/ansible-9.build
+++ b/9/ansible-9.build
@@ -68,6 +68,7 @@ hetzner.hcloud: >=2.1.0,<3.0.0
 hpe.nimble: >=1.1.0,<2.0.0
 ibm.qradar: >=2.1.0,<3.0.0
 ibm.spectrum_virtualize: >=2.0.0,<3.0.0
+ibm.storage_virtualize: >=2.1.0,<3.0.0
 infinidat.infinibox: >=1.3.0,<2.0.0
 infoblox.nios_modules: >=1.5.0,<2.0.0
 inspur.ispim: >=2.1.0,<3.0.0

--- a/9/ansible.in
+++ b/9/ansible.in
@@ -65,6 +65,7 @@ hetzner.hcloud
 hpe.nimble
 ibm.qradar
 ibm.spectrum_virtualize
+ibm.storage_virtualize
 infinidat.infinibox
 infoblox.nios_modules
 inspur.ispim

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -84,7 +84,7 @@ releases:
     changes:
       deprecated_features:
       - The collection ``ibm.spectrum_virtualize`` has been renamed to ``ibm.storage_virtualize``.
-        For now both collections are included in Ansible. The content in ``ibm.spectrum_virtualize``
+        For now, both collections are included in Ansible. The content in ``ibm.spectrum_virtualize``
         will be replaced with deprecated redirects to the new collection in Ansible 10.0.0,
         and these redirects will eventually be removed from Ansible. Please update your
         FQCNs for ``ibm.spectrum_virtualize``.

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -80,3 +80,11 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2023-10-17'
+  9.0.0b1:
+    changes:
+      deprecated_features:
+      - The collection ``ibm.spectrum_virtualize`` has been renamed to ``ibm.storage_virtualize``.
+        For now both collections are included in Ansible. The content in ``ibm.spectrum_virtualize``
+        will be replaced with deprecated redirects to the new collection in Ansible 10.0.0,
+        and these redirects will eventually be removed from Ansible. Please update your
+        FQCNs for ``ibm.spectrum_virtualize``.

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -136,7 +136,7 @@ collections:
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
   ibm.storage_virtualize:
     maintainers:
-      - Shilpi-J
+      - sumitguptaibm
     repository: https://github.com/ansible-collections/ibm.storage_virtualize
   vultr.cloud:
     maintainers:

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -134,6 +134,10 @@ collections:
     maintainers:
       - Shilpi-J
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
+  ibm.storage_virtualize:
+    maintainers:
+      - Shilpi-J
+    repository: https://github.com/ansible-collections/ibm.storage_virtualize
   vultr.cloud:
     maintainers:
       - resmo


### PR DESCRIPTION
~~Unfortunately step 4 from the checklist (#306) cannot be implemented since the original repository has been archived already.~~

~~Because of that I marked this PR as a draft, since the changelog entries now don't really make sense.~~

Closes #306.