### PR TITLE
fortinet.fortios 2.3.4 has not been tagged

### DIFF
--- a/8/ansible-8.constraints
+++ b/8/ansible-8.constraints
@@ -1,3 +1,4 @@
+fortinet.fortios: <2.3.4
 netapp.aws: <21.7.1
 netapp.azure: <21.10.1
 netapp.cloudmanager: <21.22.1

--- a/9/ansible-9.constraints
+++ b/9/ansible-9.constraints
@@ -1,3 +1,4 @@
+fortinet.fortios: <2.3.4
 netapp.aws: <21.7.1
 netapp.azure: <21.10.1
 netapp.cloudmanager: <21.22.1


### PR DESCRIPTION
Add constraints for Ansible 8 and 9 builds to stick to the last tagged version.

Ref: https://github.com/ansible-community/ansible-build-data/issues/223
Ref: https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection/issues/277
