### PR TITLE
docs/release-process.md: use consistent placeholder syntax

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -104,7 +104,7 @@ This only needs to be done once.
    cd build/ansible-build-data
    git switch -c release-${VERSION}
    git add ${MAJOR_VERSION}/
-   git commit -m "Ansible {VERSION}: Dependencies, changelog and porting guide"
+   git commit -m "Ansible ${VERSION}: Dependencies, changelog and porting guide"
    git push -u ${USERNAME} release-${VERSION}
    ```
 


### PR DESCRIPTION
There was one placeholder value missed in f9a48c3a160c2464df059cbb9c01658108f115c7.

Relates: f9a48c3a160c2464df059cbb9c01658108f115c7
