### PR TITLE
Revert "8: pin purestorage.flasharray to previous release"

### DIFF
--- a/8/ansible-8.constraints
+++ b/8/ansible-8.constraints
@@ -1,2 +1,0 @@
-# purestorage.flasharray 1.22.0 has Breaking Changes in its changelog
-purestorage.flasharray: <1.22.0


### PR DESCRIPTION
This reverts commit 6fd2b9dc86f5b4d2dd6ed4714307ac65f29ef751.

Ref: https://github.com/ansible-community/ansible-build-data/issues/223#issuecomment-1799356142
