### PR TITLE
README: clarify what the issue tracker covers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ may be referred to by other projects and scripts.
 
 ## Issue tracker
 
-The [issue track of this repository](https://github.com/ansible-community/ansible-build-data/issues) is to track various aspects of the `ansible` build, including:
+[This repository's issue tracker](https://github.com/ansible-community/ansible-build-data/issues) handles various aspects of the `ansible` build, including:
 
 1. Tracking release dates,
 1. Tracking blockers for a release,
@@ -15,10 +15,10 @@ The [issue track of this repository](https://github.com/ansible-community/ansibl
 1. Tracking problems with a release related to the build process:
    - This includes problems that prevent the package to be installed or system packages to be built from the PyPI release;
 1. Tracking and discussing other problems with the `ansible` community package:
-   - This includes important problems with the included collections that are not reacted on by the collection maintainers, for example largescale incompatibilities with the current ansible-core version, violations of semantic versioning, and general violations of the [Ansible inclusion requirements](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html);
+   - This includes important problems with the included collections that are not acted on by the collection maintainers, for example largescale incompatibilities with the current ansible-core version, violations of semantic versioning, and general violations of the [Ansible inclusion requirements](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html);
    - This includes major or security bugs in collections with wide-reaching consequences that are not addressed by the collection maintainers, or cannot be addressed on the collection level for some reason.
 
-This issue tracker is **not** for tracking regular bugs, feature requests, or for asking for help with collections included in the `ansible` package. **Such issues will be closed.** Instead, check out the issue trackers of the respective collections, or consider [asking for help in the Ansible forum](https://forum.ansible.com/).
+This issue tracker is **not** for tracking regular bugs or feature requests for `ansible-core` or the collections in included in the `ansible` package or for user support. **Such issues will be closed.** Instead, check out the [`ansible-core` issue tracker](https://github.com/ansible/ansible), issue trackers of the respective collections, or consider [asking for help in the Ansible forum](https://forum.ansible.com/).
 
 ## Milestones
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ may be referred to by other projects and scripts.
    - This includes important problems with the included collections that are not acted on by the collection maintainers, for example largescale incompatibilities with the current ansible-core version, violations of semantic versioning, and general violations of the [Ansible inclusion requirements](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html);
    - This includes major or security bugs in collections with wide-reaching consequences that are not addressed by the collection maintainers, or cannot be addressed on the collection level for some reason.
 
-This issue tracker is **not** for tracking regular bugs or feature requests for `ansible-core` or the collections in included in the `ansible` package or for user support. **Such issues will be closed.** Instead, check out the [`ansible-core` issue tracker](https://github.com/ansible/ansible), issue trackers of the respective collections, or consider [asking for help in the Ansible forum](https://forum.ansible.com/).
+This issue tracker is **not** for tracking regular bugs or feature requests for `ansible-core` or the collections included in the `ansible` package or for user support. **Such issues will be closed.** Instead, check out the [`ansible-core` issue tracker](https://github.com/ansible/ansible), issue trackers of the respective collections, or consider [asking for help in the Ansible forum](https://forum.ansible.com/).
 
 ## Milestones
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The [issue track of this repository](https://github.com/ansible-community/ansibl
 
 1. Tracking release dates,
 1. Tracking blockers for a release,
+1. Tracking adding, renaming, and removing collections,
 1. Tracking problems with a release related to the build process:
    - This includes problems that prevent the package to be installed or system packages to be built from the PyPI release;
 1. Tracking and discussing other problems with the `ansible` community package:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The [issue track of this repository](https://github.com/ansible-community/ansibl
 1. Tracking problems with a release related to the build process:
    - This includes problems that prevent the package to be installed or system packages to be built from the PyPI release;
 1. Tracking and discussing other problems with the `ansible` community package:
-   - This includes important problems with the included collections that are not reacted on by the collection maintainers, for example largescale incompatibilities with the current ansible-core version, violation of semantic versioning, and general violation of the [Ansible inclusion requirements](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html);
+   - This includes important problems with the included collections that are not reacted on by the collection maintainers, for example largescale incompatibilities with the current ansible-core version, violations of semantic versioning, and general violations of the [Ansible inclusion requirements](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html);
    - This includes major or security bugs in collections with wide-reaching consequences that are not addressed by the collection maintainers, or cannot be addressed on the collection level for some reason.
 
 This issue tracker is **not** for tracking regular bugs, feature requests, or for asking for help with collections included in the `ansible` package. **Such issues will be closed.** Instead, check out the issue trackers of the respective collections, or consider [asking for help in the Ansible forum](https://forum.ansible.com/).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@
 Holds generated but persistent results from building the `ansible` community package.  This information
 may be referred to by other projects and scripts.
 
+## Issue tracker
+
+The [issue track of this repository](https://github.com/ansible-community/ansible-build-data/issues) is to track various aspects of the `ansible` build, including:
+
+1. Tracking release dates,
+1. Tracking blockers for a release,
+1. Tracking problems with a release related to the build process:
+   - This includes problems that prevent the package to be installed or system packages to be built from the PyPI release;
+1. Tracking and discussing other problems with the `ansible` community package:
+   - This includes important problems with the included collections that are not reacted on by the collection maintainers, for example largescale incompatibilities with the current ansible-core version, violation of semantic versioning, and general violation of the [Ansible inclusion requirements](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html);
+   - This includes major or security bugs in collections with wide-reaching consequences that are not addressed by the collection maintainers, or cannot be addressed on the collection level for some reason.
+
+This issue tracker is **not** for tracking regular bugs, feature requests, or for asking for help with collections included in the `ansible` package. **Such issues will be closed.** Instead, check out the issue trackers of the respective collections, or consider [asking for help in the Ansible forum](https://forum.ansible.com/).
+
 ## Milestones
 
 Release engineers check the [milestones](https://github.com/ansible-community/ansible-build-data/milestones) for corresponding releases some time before releasing the package sufficient to solve all related issues.


### PR DESCRIPTION
In the forum, it was was remarked that it is not clear what kind of issues can and should be created in this repository's issue tracker. This PR adds a section at the top of the README with some details on what can (and what should not be) handled here.

Ref: https://forum.ansible.com/t/trying-to-get-a-message-to-the-right-team-about-a-8-6-release-issue/2274/3