### PR TITLE
new-ansible-and-freezes: fix changelog block indentation

### DIFF
--- a/docs/new-ansible-and-freezes.md
+++ b/docs/new-ansible-and-freezes.md
@@ -120,6 +120,8 @@ releases require special handling before running the release playbook.
       ${VERSION}:
         changes:
           release_summary: 'Release Date: ${RELEASE_DATE}
+
+
             `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
         release_date: '${RELEASE_DATE}'
     ```


### PR DESCRIPTION
There should be a paragraph break between `Release Date:` and the
Porting Guide link.
