### PR TITLE
VMware collection maintainers

### DIFF
--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -124,8 +124,6 @@ collections:
       - rainerleber
     repository: https://github.com/sap-linuxlab/community.sap_libs
   vmware.vmware_rest:
-    maintainers:
-      - goneri
     repository: https://github.com/ansible-collections/vmware.vmware_rest
   cisco.dnac:
     maintainers:
@@ -234,6 +232,8 @@ collections:
   community.routeros:
     repository: https://github.com/ansible-collections/community.routeros
   community.vmware:
+    maintainers:
+      - mariolenz
     repository: https://github.com/ansible-collections/community.vmware
   community.windows:
     repository: https://github.com/ansible-collections/community.windows

--- a/8/collection-meta.yaml
+++ b/8/collection-meta.yaml
@@ -124,8 +124,6 @@ collections:
       - rainerleber
     repository: https://github.com/sap-linuxlab/community.sap_libs
   vmware.vmware_rest:
-    maintainers:
-      - goneri
     repository: https://github.com/ansible-collections/vmware.vmware_rest
   cisco.dnac:
     maintainers:
@@ -242,6 +240,8 @@ collections:
   community.skydive:
     repository: https://github.com/ansible-collections/skydive
   community.vmware:
+    maintainers:
+      - mariolenz
     repository: https://github.com/ansible-collections/community.vmware
   community.windows:
     repository: https://github.com/ansible-collections/community.windows

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -124,8 +124,6 @@ collections:
       - rainerleber
     repository: https://github.com/sap-linuxlab/community.sap_libs
   vmware.vmware_rest:
-    maintainers:
-      - goneri
     repository: https://github.com/ansible-collections/vmware.vmware_rest
   cisco.dnac:
     maintainers:
@@ -234,6 +232,8 @@ collections:
   community.routeros:
     repository: https://github.com/ansible-collections/community.routeros
   community.vmware:
+    maintainers:
+      - mariolenz
     repository: https://github.com/ansible-collections/community.vmware
   community.windows:
     repository: https://github.com/ansible-collections/community.windows


### PR DESCRIPTION
@goneri doesn't maintain `vmware.vmware_rest` any more. I'm afraid that, although some people are actively working on the collection and are preparing a new release, there are no named maintainers right now :-/

On the other hand, I'd like to add myself as the maintainer of `community.vmware`. Just realized this hasn't been documented yet.