### PR TITLE
10: constrain ansible.utils to <3.0.0

### DIFF
--- a/10/ansible-10.constraints
+++ b/10/ansible-10.constraints
@@ -1,0 +1,6 @@
+# cisco.ise 2.6.2 version_conflict: ansible.utils-3.0.0 but needs >=2.0.0,<3.0
+# cisco.dnac 6.8.1 version_conflict: ansible.utils-3.0.0 but needs >=2.0.0,<3.0
+# cisco.meraki 2.16.16 version_conflict: ansible.utils-3.0.0 but needs >=2.0.0,<3.0
+ansible.utils: <3.0.0
+# ansible.netcommon 6.0.0 version_conflict: ansible.utils-2.12.0 but needs >=3.0.0
+ansible.netcommon: <6.0.0

--- a/10/ansible-10.constraints
+++ b/10/ansible-10.constraints
@@ -4,3 +4,12 @@
 ansible.utils: <3.0.0
 # ansible.netcommon 6.0.0 version_conflict: ansible.utils-2.12.0 but needs >=3.0.0
 ansible.netcommon: <6.0.0
+# Other collections that require `ansible.netcommon>=6.0.0`
+arista.eos: <7.0.0
+cisco.asa: <5.0.0
+cisco.ios: <6.0.0
+cisco.iosxr: <7.0.0
+cisco.nxos: <6.0.0
+ibm.qradar: <3.0.0
+junipernetworks.junos: <6.0.0
+splunk.es: <3.0.0


### PR DESCRIPTION
```
ERROR: found collection dependency errors!
ERROR: cisco.ise 2.6.2 version_conflict: ansible.utils-3.0.0 but needs >=2.0.0,<3.0
ERROR: cisco.dnac 6.8.1 version_conflict: ansible.utils-3.0.0 but needs >=2.0.0,<3.0
ERROR: cisco.meraki 2.16.16 version_conflict: ansible.utils-3.0.0 but needs >=2.0.0,<3.0
```