### PR TITLE
mkdocs.yml: fix copyright footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,7 @@ theme:
 # REUSE-IgnoreStart
 copyright: >
   Copyright (C) 2023 Ansible Project Authors |
-  SPDX-License-Identifier: <a style="text-decoration: underline;" href="https://github.com/ansible/ansible/blob/devel/COPYING">GPL-3.0-only</a>
+  SPDX-License-Identifier: <a style="text-decoration: underline;" href="https://github.com/ansible-community/ansible-build-data/blob/main/LICENSE">GPL-3.0-or-later</a>
 # REUSE-IgnoreEnd
 markdown_extensions:
   # Builtin


### PR DESCRIPTION
The license is GPLv3 *or later,* and we should link to our own LICENSE
file, not the one in core.
