### PR TITLE
Run CI at least once weekly

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -4,6 +4,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Run once per week (Thursday at 04:00 UTC)
+  schedule:
+    - cron: '0 4 * * 4'
 
 jobs:
   build:


### PR DESCRIPTION
Right now it only runs on demand. While there's an antsibull-build regular run in the antsibull repository, it would be nice to also have one here to detect build problems on early.

(I've set the day to run to Thursday, since the weekly CI in antsibull runs on Monday.)