### PR TITLE
Remove hpe.nimble from Ansible 10

### DIFF
--- a/10/ansible.in
+++ b/10/ansible.in
@@ -62,7 +62,6 @@ gluster.gluster
 google.cloud
 grafana.grafana
 hetzner.hcloud
-hpe.nimble
 ibm.qradar
 ibm.spectrum_virtualize
 ibm.storage_virtualize

--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -6,3 +6,6 @@ releases:
       removed_features:
         - The deprecated ``community.azure`` collection has been removed.
           There is a successor collection ``azure.azcollection`` in the community package which should cover the same functionality.
+        - The ``hpe.nimble`` collection was considered unmaintained and removed from Ansible 10
+          (https://github.com/ansible-community/community-topics/issues/254).
+          Users can still install this collection with ``ansible-galaxy collection install hpe.nimble``.

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -53,12 +53,6 @@ collections:
     maintainers:
       - javeedf
     repository: https://github.com/ansible-collections/dellemc.enterprise_sonic
-  hpe.nimble:
-    maintainers:
-      - ar-india
-      - datamattsson
-    repository: https://github.com/hpe-storage/nimble-ansible-modules
-    collection-directory: "./ansible_collection/hpe/nimble"
   netapp.azure:
     maintainers:
       - carchi8py


### PR DESCRIPTION
Fixes #285

Remove hpe.nimble from Ansible 10 as discussed in ansible-community/community-topics#254 and announced in #284