### PR TITLE
Remove gluster.gluster from Ansible 10

### DIFF
--- a/10/ansible.in
+++ b/10/ansible.in
@@ -58,7 +58,6 @@ f5networks.f5_modules
 fortinet.fortimanager
 fortinet.fortios
 frr.frr
-gluster.gluster
 google.cloud
 grafana.grafana
 hetzner.hcloud

--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -9,3 +9,6 @@ releases:
         - The ``hpe.nimble`` collection was considered unmaintained and removed from Ansible 10
           (https://github.com/ansible-community/community-topics/issues/254).
           Users can still install this collection with ``ansible-galaxy collection install hpe.nimble``.
+        - The ``gluster.gluster`` collection was considered unmaintained and removed from Ansible 10
+          (https://github.com/ansible-community/community-topics/issues/225).
+          Users can still install this collection with ``ansible-galaxy collection install gluster.gluster``.

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -278,8 +278,6 @@ collections:
     repository: https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection
   frr.frr:
     repository: https://github.com/ansible-collections/frr.frr
-  gluster.gluster:
-    repository: https://github.com/gluster/gluster-ansible-collection
   google.cloud:
     repository: https://github.com/ansible-collections/google.cloud
   hetzner.hcloud:


### PR DESCRIPTION
Fixes #249

Remove gluster.gluster from Ansible 10 as discussed in ansible-community/community-topics#225 and announced in #248