### PR TITLE
Remove netapp.elementsw from Ansible 10

### DIFF
--- a/10/ansible.in
+++ b/10/ansible.in
@@ -75,7 +75,6 @@ microsoft.ad
 netapp.aws
 netapp.azure
 netapp.cloudmanager
-netapp.elementsw
 netapp_eseries.santricity
 netapp.ontap
 netapp.storagegrid

--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -12,3 +12,6 @@ releases:
         - The ``gluster.gluster`` collection was considered unmaintained and removed from Ansible 10
           (https://github.com/ansible-community/community-topics/issues/225).
           Users can still install this collection with ``ansible-galaxy collection install gluster.gluster``.
+        - The ``netapp.elementsw`` collection was considered unmaintained and removed from Ansible 10
+          (https://github.com/ansible-community/community-topics/issues/235).
+          Users can still install this collection with ``ansible-galaxy collection install netapp.elementsw``.

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -295,8 +295,6 @@ collections:
       - wenjun666
       - chuyich
     repository: https://github.com/ansible-collections/netapp.aws
-  netapp.elementsw:
-    repository: https://github.com/ansible-collections/netapp.elementsw
   netapp.ontap:
     maintainers:
       - carchi8py


### PR DESCRIPTION
Fixes #276

Remove netapp.elementsw from Ansible 10 as discussed in ansible-community/community-topics#235 and announced in #275