### PR TITLE
Remove netapp.aws from Ansible 10

### DIFF
--- a/10/ansible.in
+++ b/10/ansible.in
@@ -72,7 +72,6 @@ junipernetworks.junos
 kubernetes.core
 lowlydba.sqlserver
 microsoft.ad
-netapp.aws
 netapp.azure
 netapp.cloudmanager
 netapp_eseries.santricity

--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -15,3 +15,6 @@ releases:
         - The ``netapp.elementsw`` collection was considered unmaintained and removed from Ansible 10
           (https://github.com/ansible-community/community-topics/issues/235).
           Users can still install this collection with ``ansible-galaxy collection install netapp.elementsw``.
+        - The ``netapp.aws`` collection was considered unmaintained and removed from Ansible 10
+          (https://github.com/ansible-community/community-topics/issues/223).
+          Users can still install this collection with ``ansible-galaxy collection install netapp.aws``.

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -288,13 +288,6 @@ collections:
     repository: https://github.com/infinidat/ansible-infinidat-collection
   junipernetworks.junos:
     repository: https://github.com/ansible-collections/junipernetworks.junos
-  netapp.aws:
-    maintainers:
-      - carchi8py
-      - suhasbshekar
-      - wenjun666
-      - chuyich
-    repository: https://github.com/ansible-collections/netapp.aws
   netapp.ontap:
     maintainers:
       - carchi8py


### PR DESCRIPTION
Fixes #243

Remove netapp.elementsw from Ansible 10 as discussed in ansible-community/community-topics#223 and announced in #242