### PR TITLE
Remove netapp.azure from Ansible 10

### DIFF
--- a/10/ansible.in
+++ b/10/ansible.in
@@ -72,7 +72,6 @@ junipernetworks.junos
 kubernetes.core
 lowlydba.sqlserver
 microsoft.ad
-netapp.azure
 netapp.cloudmanager
 netapp_eseries.santricity
 netapp.ontap

--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -18,3 +18,6 @@ releases:
         - The ``netapp.aws`` collection was considered unmaintained and removed from Ansible 10
           (https://github.com/ansible-community/community-topics/issues/223).
           Users can still install this collection with ``ansible-galaxy collection install netapp.aws``.
+        - The ``netapp.azure`` collection was considered unmaintained and removed from Ansible 10
+          (https://github.com/ansible-community/community-topics/issues/234).
+          Users can still install this collection with ``ansible-galaxy collection install netapp.azure``.

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -53,13 +53,6 @@ collections:
     maintainers:
       - javeedf
     repository: https://github.com/ansible-collections/dellemc.enterprise_sonic
-  netapp.azure:
-    maintainers:
-      - carchi8py
-      - suhasbshekar
-      - wenjun666
-      - chuyich
-    repository: https://github.com/ansible-collections/netapp.azure
   netapp.cloudmanager:
     maintainers:
       - carchi8py


### PR DESCRIPTION
Fixes #272

Remove netapp.azure from Ansible 10 as discussed in ansible-community/community-topics#234 and announced in #271