### PR TITLE
Remove netapp.um_info from Ansible 10

### DIFF
--- a/10/ansible.in
+++ b/10/ansible.in
@@ -76,7 +76,6 @@ netapp.cloudmanager
 netapp_eseries.santricity
 netapp.ontap
 netapp.storagegrid
-netapp.um_info
 netbox.netbox
 ngine_io.cloudstack
 ngine_io.exoscale

--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -21,3 +21,6 @@ releases:
         - The ``netapp.azure`` collection was considered unmaintained and removed from Ansible 10
           (https://github.com/ansible-community/community-topics/issues/234).
           Users can still install this collection with ``ansible-galaxy collection install netapp.azure``.
+        - The ``netapp.um_info`` collection was considered unmaintained and removed from Ansible 10
+          (https://github.com/ansible-community/community-topics/issues/244).
+          Users can still install this collection with ``ansible-galaxy collection install netapp.um_info``.

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -60,13 +60,6 @@ collections:
       - wenjun666
       - chuyich
     repository: https://github.com/ansible-collections/netapp.cloudmanager
-  netapp.um_info:
-    maintainers:
-      - carchi8py
-      - suhasbshekar
-      - wenjun666
-      - chuyich
-    repository: https://github.com/ansible-collections/netapp.um_info
   community.ciscosmb:
     maintainers:
       - qaxi


### PR DESCRIPTION
Fixes #280

Remove netapp.um_info from Ansible 10 as discussed in ansible-community/community-topics#244 and announced in #279