### PR TITLE
Remove community.sap from Ansible 10

### DIFF
--- a/10/ansible.in
+++ b/10/ansible.in
@@ -41,7 +41,6 @@ community.postgresql
 community.proxysql
 community.rabbitmq
 community.routeros
-community.sap
 community.sap_libs
 community.sops
 community.vmware

--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -24,3 +24,6 @@ releases:
         - The ``netapp.um_info`` collection was considered unmaintained and removed from Ansible 10
           (https://github.com/ansible-community/community-topics/issues/244).
           Users can still install this collection with ``ansible-galaxy collection install netapp.um_info``.
+        - The deprecated ``community.sap`` collection has been removed from Ansible 10
+          (https://github.com/ansible-community/community-topics/issues/247).
+          There is a successor collection ``community.sap_libs`` in the community package which should cover the same functionality.

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -95,10 +95,6 @@ collections:
       - racampos
       - jbogarin
     repository: https://github.com/CiscoISE/ansible-ise
-  community.sap:
-    maintainers:
-      - rainerleber
-    repository: https://github.com/ansible-collections/community.sap
   community.sap_libs:
     maintainers:
       - rainerleber


### PR DESCRIPTION
Fixes #266

Remove community.sap from Ansible 10 as discussed in ansible-community/community-topics#247 and  announced in #262