### PR TITLE
Revert "infinidat.infinibox 1.4.0 is not tagged. (#365)"

### DIFF
--- a/10/ansible-10.constraints
+++ b/10/ansible-10.constraints
@@ -1,2 +1,0 @@
-# 1.4.0 is not tagged
-infinidat.infinibox: !=1.4.0

--- a/9/ansible-9.constraints
+++ b/9/ansible-9.constraints
@@ -1,2 +1,0 @@
-# 1.4.0 is not tagged
-infinidat.infinibox: !=1.4.0


### PR DESCRIPTION
This reverts commit ecd20cb95f69a3e8dcb6be373d13433fd047a104.

Ref: https://github.com/Infinidat/ansible-infinidat-collection/issues/20
Ref: https://github.com/ansible-community/ansible-build-data/issues/223