### PR TITLE
Remove purestorage.fusion from Ansible 10

### DIFF
--- a/10/ansible.in
+++ b/10/ansible.in
@@ -83,7 +83,6 @@ openvswitch.openvswitch
 ovirt.ovirt
 purestorage.flasharray
 purestorage.flashblade
-purestorage.fusion
 sensu.sensu_go
 splunk.es
 theforeman.foreman

--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -36,3 +36,5 @@ releases:
         - The deprecated ``community.sap`` collection has been removed from Ansible 10
           (https://github.com/ansible-community/community-topics/issues/247).
           There is a successor collection ``community.sap_libs`` in the community package which should cover the same functionality.
+        - The deprecated ``purestorage.fusion`` collection has been removed
+          (https://forum.ansible.com/t/3712).

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -116,10 +116,6 @@ collections:
       - racampos
       - wastorga
     repository: https://github.com/cisco-en-programmability/dnacenter-ansible
-  purestorage.fusion:
-    maintainers:
-      - sdodsley
-    repository: https://github.com/Pure-Storage-Ansible/Fusion-Collection
   ibm.spectrum_virtualize:
     maintainers:
       - Shilpi-J

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -139,3 +139,6 @@ releases:
           from Ansible 11 if no one starts maintaining it again before Ansible 11. See
           `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
           (https://forum.ansible.com/t/2811).
+        - The ``purestorage.fusion`` collection is officially unmaintained and has been
+          archived. Therefore, it will be removed from Ansible 10
+          (https://forum.ansible.com/t/3712).


### PR DESCRIPTION
Remove purestorage.fusion from Ansible 10 as discussed and voted on in [Deprecation/Removal of purestorage.fusion from the community Ansible package](https://forum.ansible.com/t/3712)