### PR TITLE
cd ansible-release: include artifact URL in PR body

### DIFF
--- a/.github/workflows/ansible-release.yml
+++ b/.github/workflows/ansible-release.yml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
+        id: upload-artifact
         with:
           name: sdist-and-wheel
           path: antsibull/build/ansible-*.*
@@ -93,12 +94,14 @@ jobs:
         working-directory: antsibull/build/ansible-build-data
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: >-
-          gh pr create
-          --base main
-          --head "publish-${ANSIBLE_VERSION}"
-          --title "Release Ansible ${ANSIBLE_VERSION}"
-          --body "${CI_COMMIT_MESSAGE}"
+          ARTIFACT_URL: ${{ steps.upload-artifact.outputs.artifact-url }}
+        run: |
+          body="$(echo "${CI_COMMIT_MESSAGE}\nRelease artifacts: <${ARTIFACT_URL}>")"
+          gh pr create \
+          --base main \
+          --head "publish-${ANSIBLE_VERSION}" \
+          --title "Release Ansible ${ANSIBLE_VERSION}" \
+          --body "${body}"
 
   # publish job downloads the arifacts and publish it to PyPI
 

--- a/.github/workflows/ansible-release.yml
+++ b/.github/workflows/ansible-release.yml
@@ -96,7 +96,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACT_URL: ${{ steps.upload-artifact.outputs.artifact-url }}
         run: |
-          body="$(echo "${CI_COMMIT_MESSAGE}\nRelease artifacts: <${ARTIFACT_URL}>")"
+          body="$(echo -e "${CI_COMMIT_MESSAGE}\nRelease artifacts: <${ARTIFACT_URL}>")"
           gh pr create \
           --base main \
           --head "publish-${ANSIBLE_VERSION}" \


### PR DESCRIPTION
This exposes the release artifact download URL in the PR body so we can access it while reviewing the release PR.