### PR TITLE
Prune community.sap from Ansible 10

### DIFF
--- a/10/ansible-10.build
+++ b/10/ansible-10.build
@@ -44,7 +44,6 @@ community.postgresql: >=3.4.0,<4.0.0
 community.proxysql: >=1.5.0,<2.0.0
 community.rabbitmq: >=1.3.0,<2.0.0
 community.routeros: >=2.14.0,<3.0.0
-community.sap_libs: >=1.4.0,<2.0.0
 community.sops: >=1.6.0,<2.0.0
 community.vmware: >=4.2.0,<5.0.0
 community.windows: >=2.2.0,<3.0.0

--- a/10/ansible.in
+++ b/10/ansible.in
@@ -41,7 +41,6 @@ community.postgresql
 community.proxysql
 community.rabbitmq
 community.routeros
-community.sap_libs
 community.sops
 community.vmware
 community.windows

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -95,10 +95,6 @@ collections:
       - racampos
       - jbogarin
     repository: https://github.com/CiscoISE/ansible-ise
-  community.sap_libs:
-    maintainers:
-      - rainerleber
-    repository: https://github.com/sap-linuxlab/community.sap_libs
   vmware.vmware_rest:
     maintainers:
       # ansible-collections/cloud

--- a/10/galaxy-requirements.yaml
+++ b/10/galaxy-requirements.yaml
@@ -129,9 +129,6 @@ collections:
 - name: community.routeros
   source: https://galaxy.ansible.com
   version: 2.14.0
-- name: community.sap_libs
-  source: https://galaxy.ansible.com
-  version: 1.4.2
 - name: community.sops
   source: https://galaxy.ansible.com
   version: 1.6.7


### PR DESCRIPTION
This collection is starting to haunt me. We've removed it (for the second time!) in #360. But it still turns up in some files :tired_face: 