### PR TITLE
Undo Ansible 9 pin for community.ciscosmb < 1.0.8

### DIFF
--- a/9/ansible-9.constraints
+++ b/9/ansible-9.constraints
@@ -1,2 +1,0 @@
-# community.ciscosmb introduced a breaking change by renaming a fact
-community.ciscosmb: <1.0.8


### PR DESCRIPTION
community.ciscosmb 1.0.9 reverts the breaking change from 1.0.8.

Closes https://github.com/ansible-collections/community.ciscosmb/issues/75.