### PR TITLE
Release workflow: ensure that all history is there for tagging

### DIFF
--- a/.github/workflows/ansible-release.yml
+++ b/.github/workflows/ansible-release.yml
@@ -219,6 +219,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
 
       - name: Create git tag
         env:


### PR DESCRIPTION
Without this, tagging everything but the latest commit will fail. This happened today when releasing 10.0.0b1: https://github.com/ansible-community/ansible-build-data/actions/runs/9172023176/job/25220255138