### PR TITLE
Remove inspur.sm from Ansible 11

### DIFF
--- a/11/ansible.in
+++ b/11/ansible.in
@@ -66,7 +66,6 @@ ibm.storage_virtualize
 infinidat.infinibox
 infoblox.nios_modules
 inspur.ispim
-inspur.sm
 junipernetworks.junos
 kaytus.ksmanage
 kubernetes.core

--- a/11/changelog.yaml
+++ b/11/changelog.yaml
@@ -1,3 +1,9 @@
 ---
 ancestor: 10.0.0
-releases: {}
+releases:
+  11.0.0a1:
+    changes:
+      removed_features:
+      - The ``inspur.sm`` collection was considered unmaintained and removed
+        from Ansible 11 (https://forum.ansible.com/t/2854).
+        Users can still install this collection with ``ansible-galaxy collection install inspur.sm``.

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -22,10 +22,6 @@ collections:
     maintainers:
       - ispim
     repository: https://github.com/ispim/inspur.ispim
-  inspur.sm:
-    maintainers:
-      - ISIB-Group
-    repository: https://github.com/ISIB-Group/inspur.sm
   kaytus.ksmanage:
     maintainers:
       - ieisystem


### PR DESCRIPTION
Fixes #363 

Remove inspur.sm from Ansible 11 as discussed in [Unmaintained collection: inspur.sm](https://forum.ansible.com/t/2854) and announced in #362.