### PR TITLE
Revert "Add kubevirt.core to Ansible 10 and 11. (#419)"

### DIFF
--- a/10/ansible-10.build
+++ b/10/ansible-10.build
@@ -73,7 +73,6 @@ inspur.sm: >=2.3.0,<3.0.0
 junipernetworks.junos: >=8.0.0,<9.0.0
 kaytus.ksmanage: >=1.2.0,<2.0.0
 kubernetes.core: >=3.1.0,<4.0.0
-kubevirt.core: >=1.4.0,<2.0.0
 lowlydba.sqlserver: >=2.3.0,<3.0.0
 microsoft.ad: >=1.5.0,<2.0.0
 netapp.cloudmanager: >=21.22.0,<22.0.0

--- a/10/ansible.in
+++ b/10/ansible.in
@@ -70,7 +70,6 @@ inspur.sm
 junipernetworks.junos
 kaytus.ksmanage
 kubernetes.core
-kubevirt.core
 lowlydba.sqlserver
 microsoft.ad
 netapp.cloudmanager

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -36,11 +36,6 @@ collections:
       - akasurde
       - gravesm
     repository: https://github.com/ansible-collections/kubernetes.core
-  kubevirt.core:
-    maintainers:
-      - 0xFelix
-      - guidograzioli
-    repository: https://github.com/kubevirt/kubevirt.core
   sensu.sensu_go:
     maintainers:
       - tadeboro

--- a/11/ansible.in
+++ b/11/ansible.in
@@ -69,7 +69,6 @@ inspur.ispim
 junipernetworks.junos
 kaytus.ksmanage
 kubernetes.core
-kubevirt.core
 lowlydba.sqlserver
 microsoft.ad
 netapp.cloudmanager

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -32,11 +32,6 @@ collections:
       - akasurde
       - gravesm
     repository: https://github.com/ansible-collections/kubernetes.core
-  kubevirt.core:
-    maintainers:
-      - 0xFelix
-      - guidograzioli
-    repository: https://github.com/kubevirt/kubevirt.core
   sensu.sensu_go:
     maintainers:
       - tadeboro


### PR DESCRIPTION
This reverts commit b60fb7b9005b14941a2578a4e648341e4776c5c2.

Reverts PR #419.

Ref: https://github.com/ansible-community/ansible-build-data/pull/419#issuecomment-2169497635
Ref: https://github.com/kubevirt/kubevirt.core/issues/110

Let's re-add it once the dependency on kubernetes.core is less strict.