### PR TITLE
Remove netapp.storagegrid from Ansible 11

### DIFF
--- a/11/ansible.in
+++ b/11/ansible.in
@@ -75,7 +75,6 @@ microsoft.ad
 netapp.cloudmanager
 netapp_eseries.santricity
 netapp.ontap
-netapp.storagegrid
 netbox.netbox
 ngine_io.cloudstack
 ngine_io.exoscale

--- a/11/changelog.yaml
+++ b/11/changelog.yaml
@@ -7,3 +7,6 @@ releases:
       - The ``inspur.sm`` collection was considered unmaintained and removed
         from Ansible 11 (https://forum.ansible.com/t/2854).
         Users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
+      - The ``netapp.storagegrid`` collection was considered unmaintained and removed
+        from Ansible 11 (https://forum.ansible.com/t/2811).
+        Users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -83,12 +83,6 @@ collections:
     maintainers:
       - jborean93
     repository: https://github.com/ansible-collections/microsoft.ad
-  netapp.storagegrid:
-    maintainers:
-      - carchi8py
-      - jkandati
-      - joshedmonds
-    repository: https://github.com/ansible-collections/netapp.storagegrid
   cisco.ise:
     maintainers:
       - wastorga


### PR DESCRIPTION
Fixes #373

Remove netapp.storagegrid from Ansible 11 as discussed in [Unmaintained collection: netapp.storagegrid](https://forum.ansible.com/t/2811) and announced in #372.