### PR TITLE
Remove frr.frr and openvswitch.openvswitch

### DIFF
--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -102,3 +102,14 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2024-06-18'
+  10.2.0:
+    changes:
+      deprecated_features:
+        - The ``frr.frr` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18,
+          it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See
+          `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
+          (https://forum.ansible.com/t/6243).
+        - The ``openvswitch.openvswitch` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18,
+          it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See
+          `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
+          (https://forum.ansible.com/t/6245).

--- a/11/ansible.in
+++ b/11/ansible.in
@@ -56,7 +56,6 @@ dellemc.unity
 f5networks.f5_modules
 fortinet.fortimanager
 fortinet.fortios
-frr.frr
 google.cloud
 grafana.grafana
 hetzner.hcloud
@@ -79,7 +78,6 @@ netbox.netbox
 ngine_io.cloudstack
 ngine_io.exoscale
 openstack.cloud
-openvswitch.openvswitch
 ovirt.ovirt
 purestorage.flasharray
 purestorage.flashblade

--- a/11/changelog.yaml
+++ b/11/changelog.yaml
@@ -4,13 +4,13 @@ releases:
   11.0.0a1:
     changes:
       removed_features:
-        - The ``inspur.sm`` collection was considered unmaintained and removed
-          from Ansible 11 (https://forum.ansible.com/t/2854).
-          Users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
-        - The ``netapp.storagegrid`` collection was considered unmaintained and removed
-          from Ansible 11 (https://forum.ansible.com/t/2811).
-          Users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
-        - The ``frr.frr` has been removed because it does not support ansible-core 2.18
-          (https://forum.ansible.com/t/6243).
-        - The ``openvswitch.openvswitch` collection has been removed because it does not support ansible-core 2.18
-          (https://forum.ansible.com/t/6245).
+      - The ``inspur.sm`` collection was considered unmaintained and removed
+        from Ansible 11 (https://forum.ansible.com/t/2854).
+        Users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
+      - The ``netapp.storagegrid`` collection was considered unmaintained and removed
+        from Ansible 11 (https://forum.ansible.com/t/2811).
+        Users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
+      - The ``frr.frr` has been removed because it does not support ansible-core 2.18
+        (https://forum.ansible.com/t/6243).
+      - The ``openvswitch.openvswitch` collection has been removed because it does not support ansible-core 2.18
+        (https://forum.ansible.com/t/6245).

--- a/11/changelog.yaml
+++ b/11/changelog.yaml
@@ -4,9 +4,13 @@ releases:
   11.0.0a1:
     changes:
       removed_features:
-      - The ``inspur.sm`` collection was considered unmaintained and removed
-        from Ansible 11 (https://forum.ansible.com/t/2854).
-        Users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
-      - The ``netapp.storagegrid`` collection was considered unmaintained and removed
-        from Ansible 11 (https://forum.ansible.com/t/2811).
-        Users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
+        - The ``inspur.sm`` collection was considered unmaintained and removed
+          from Ansible 11 (https://forum.ansible.com/t/2854).
+          Users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
+        - The ``netapp.storagegrid`` collection was considered unmaintained and removed
+          from Ansible 11 (https://forum.ansible.com/t/2811).
+          Users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
+        - The ``frr.frr` has been removed because it does not support ansible-core 2.18
+          (https://forum.ansible.com/t/6243).
+        - The ``openvswitch.openvswitch` collection has been removed because it does not support ansible-core 2.18
+          (https://forum.ansible.com/t/6245).

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -252,8 +252,6 @@ collections:
     repository: https://github.com/fortinet-ansible-dev/ansible-galaxy-fortimanager-collection
   fortinet.fortios:
     repository: https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection
-  frr.frr:
-    repository: https://github.com/ansible-collections/frr.frr
   google.cloud:
     repository: https://github.com/ansible-collections/google.cloud
   hetzner.hcloud:
@@ -281,8 +279,6 @@ collections:
     repository: https://github.com/ngine-io/ansible-collection-exoscale
   openstack.cloud:
     repository: https://opendev.org/openstack/ansible-collections-openstack
-  openvswitch.openvswitch:
-    repository: https://github.com/ansible-collections/openvswitch.openvswitch
   ovirt.ovirt:
     repository: https://github.com/ovirt/ovirt-ansible-collection
     tag_version_regex: "^(.*)-1$"

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -190,3 +190,14 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2024-06-18'
+  9.8.0:
+    changes:
+      deprecated_features:
+        - The ``frr.frr` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18,
+          it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See
+          `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
+          (https://forum.ansible.com/t/6243).
+        - The ``openvswitch.openvswitch` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18,
+          it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See
+          `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
+          (https://forum.ansible.com/t/6245).


### PR DESCRIPTION
Let's remove `frr.frr` and `openvswitch.openvswitch` from Ansible 11 since they _officially_ will not support ansible-core 2.18 (see see [here](https://github.com/ansible-collections/frr.frr/commit/90fa27060a0195a211911398d9959049985bbbba), [here](https://github.com/ansible-collections/frr.frr/commit/69fd7210ae226f66ad8556b28203a357e759e526), [here](https://github.com/ansible-collections/openvswitch.openvswitch/commit/edf3538ed34198f44ced8b7c3dd4501837a69ea0) and [here](https://github.com/ansible-collections/openvswitch.openvswitch/commit/645088eba8ec2b29b196c25559352f583bda0d6e)).

Ref: [Unmaintained collection: frr.frr](https://forum.ansible.com/t/6243)
Ref: [Unmaintained collection: openvswitch.openvswitch](https://forum.ansible.com/t/6245)
Ref: [Several collections have been deprecated by the Ansible Network team](https://forum.ansible.com/t/6360)