### PR TITLE
Check out antsiubll-docutils, and clean up nox workflow

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -53,6 +53,13 @@ jobs:
           ref: main
           path: antsibull-changelog
 
+      - name: Check out antsibull-docutils
+        uses: actions/checkout@v4
+        with:
+          repository: ansible-community/antsibull-docutils
+          ref: main
+          path: antsibull-docutils
+
       - name: Pre-create build directory
         run: mkdir -p antsibull/build
 

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -41,7 +41,7 @@ jobs:
           python-versions: "${{ matrix.python-versions }}"
       - name: Set up nox environments
         run: |
-          nox -v -e "${{ matrix.session }}" ${{ matrix.codecov && 'coverage' || '' }} --install-only
+          nox -v -e "${{ matrix.session }}" --install-only
       - name: "Run nox -e ${{ matrix.session }}"
         run: |
           nox -v -e "${{ matrix.session }}" --reuse-existing-virtualenvs --no-install

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: antsibull
+        working-directory: ansible-build-data
     strategy:
       fail-fast: false
       matrix:
@@ -31,17 +31,17 @@ jobs:
             python-versions: "3.12"
     name: "Run nox ${{ matrix.session }} session"
     steps:
-      - name: Check out antsibull
+      - name: Check out ansible-build-data
         uses: actions/checkout@v4
         with:
-          path: antsibull
+          path: ansible-build-data
       - name: Setup nox
         uses: wntrblm/nox@2024.04.15
         with:
           python-versions: "${{ matrix.python-versions }}"
       - name: Set up nox environments
         run: |
-          OTHER_ANTSIBULL_MODE=git nox -v -e "${{ matrix.session }}" ${{ matrix.codecov && 'coverage' || '' }} --install-only
+          nox -v -e "${{ matrix.session }}" ${{ matrix.codecov && 'coverage' || '' }} --install-only
       - name: "Run nox -e ${{ matrix.session }}"
         run: |
-          OTHER_ANTSIBULL_MODE=git nox -v -e "${{ matrix.session }}" --reuse-existing-virtualenvs --no-install
+          nox -v -e "${{ matrix.session }}" --reuse-existing-virtualenvs --no-install


### PR DESCRIPTION
- Check out antsibull-docutils before running antsibull in antsibull-build workflow.
- Clean up nox workflow. It was using the wrong name for the repository, and specified `OTHER_ANTSIBULL_MODE` which isn't used by this repo.