### PR TITLE
Remove mentions of the mailing list; copy announce explanation from manual to automated process docs

### DIFF
--- a/docs/automated-process.md
+++ b/docs/automated-process.md
@@ -67,7 +67,7 @@ release process. The automated processes uses GitHub Actions to automate the
     pip install antsibull[clipboard]
     ```
 
-6. Then announce the release on the Forum, the mailing list and Matrix by
+6. Then announce the release on the Forum and Matrix by
    running the following command in the `${MAJOR_VERSION}` directory of the
    `ansible-build-data` checkout:
 
@@ -75,10 +75,10 @@ release process. The automated processes uses GitHub Actions to automate the
     antsibull-build announcements --send --data-dir . ${VERSION}
     ```
 
-    This will open your default browser and email client to do the announcement
-    on the forum and the mailing list. It will also tell you where to announce
-    this on Matrix, ask for the URL of the forum thread and create a suitable
-    text in your clipboard that you can copy to Matrix.
+    This will open your default browser to do the announcement on the forum.
+    It will also tell you where to announce this on Matrix,
+    ask for the URL of the forum thread,
+    and create a suitable text in your clipboard that you can copy to Matrix.
 
 [^1]: This group is configured as "Required reviewers" for the "Configure pypi"
       build environment in GitHub Actions of the `ansible-build-data` repository.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -144,12 +144,17 @@ This only needs to be done once.
     git push --follow-tags
     ```
 
-8. Announce the release on the Forum, Matrix, and the mailing list by running
+8. Announce the release on the Forum and Matrix by running
    the following command in the `${MAJOR_VERSION}` directory of the
    `ansible-build-data` checkout:
     ```
     antsibull-build announcements --send --data-dir . ${VERSION}
     ```
+
+    This will open your default browser to do the announcement on the forum.
+    It will also tell you where to announce this on Matrix,
+    ask for the URL of the forum thread,
+    and create a suitable text in your clipboard that you can copy to Matrix.
 
 [container]: https://hub.docker.com/_/python
 [abd-fork]: https://github.com/ansible-community/ansible-build-data/fork


### PR DESCRIPTION
Ref: https://github.com/ansible-community/antsibull/pull/613

(That PR actually removes mailing list sending from antsibull.)