### PR TITLE
Add metadata to indicate which collections are unmaintained / deprecated / will be removed

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Lint collection metadata
         working-directory: antsibull/build/ansible-build-data/${{ matrix.ansible_major_version }}
         run: |
-          antsibull-build lint-collection-meta ${{ matrix.ansible_major_version }}
+          antsibull-build lint-build-data ${{ matrix.ansible_major_version }}
 
       - name: Test building a release with the defaults
         working-directory: antsibull

--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -85,7 +85,7 @@ jobs:
         working-directory: antsibull
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install ansible-core . ../antsibull-core ../antsibull-changelog
+          python3 -m pip install ansible-core . ../antsibull-core ../antsibull-changelog ../antsibull-docutils ../antsibull-fileutils
           ansible-galaxy collection install 'git+https://github.com/ansible-collections/community.general.git'
 
       - name: Test building a release with the defaults

--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -88,6 +88,11 @@ jobs:
           python3 -m pip install ansible-core . ../antsibull-core ../antsibull-changelog ../antsibull-docutils ../antsibull-fileutils
           ansible-galaxy collection install 'git+https://github.com/ansible-collections/community.general.git'
 
+      - name: Lint collection metadata
+        working-directory: antsibull/build/ansible-build-data/${{ matrix.ansible_major_version }}
+        run: |
+          antsibull-build lint-collection-meta ${{ matrix.ansible_major_version }}
+
       - name: Test building a release with the defaults
         working-directory: antsibull
         run: |

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -172,6 +172,11 @@ collections:
     repository: https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection
   frr.frr:
     repository: https://github.com/ansible-collections/frr.frr
+    removal:
+      version: 11
+      reason: deprecated
+      discussion: https://forum.ansible.com/t/6243
+      announce_version: 10.2.0
   google.cloud:
     repository: https://github.com/ansible-collections/google.cloud
   grafana.grafana:
@@ -186,6 +191,10 @@ collections:
     maintainers:
       - Shilpi-J
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
+    removal:
+      version: TBD
+      reason: renamed
+      new_name: ibm.storage_virtualize
   ibm.storage_virtualize:
     maintainers:
       - sumitguptaibm
@@ -208,6 +217,11 @@ collections:
     maintainers:
       - ISIB-Group
     repository: https://github.com/ISIB-Group/inspur.sm
+    removal:
+      version: 11
+      reason: considered-unmaintained
+      discussion: https://forum.ansible.com/t/2854
+      announce_version: 10.0.0a1
   junipernetworks.junos:
     repository: https://github.com/ansible-collections/junipernetworks.junos
   kaytus.ksmanage:
@@ -253,6 +267,11 @@ collections:
       - jkandati
       - joshedmonds
     repository: https://github.com/ansible-collections/netapp.storagegrid
+    removal:
+      version: 11
+      reason: considered-unmaintained
+      discussion: https://forum.ansible.com/t/2811
+      announce_version: 10.0.0a1
   netapp_eseries.santricity:
     repository: https://github.com/netapp-eseries/santricity
   netbox.netbox:
@@ -265,6 +284,11 @@ collections:
     repository: https://opendev.org/openstack/ansible-collections-openstack
   openvswitch.openvswitch:
     repository: https://github.com/ansible-collections/openvswitch.openvswitch
+    removal:
+      version: 11
+      reason: deprecated
+      discussion: https://forum.ansible.com/t/6245
+      announce_version: 10.2.0
   ovirt.ovirt:
     repository: https://github.com/ovirt/ovirt-ansible-collection
     tag_version_regex: "^(.*)-1$"

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -173,7 +173,7 @@ collections:
   frr.frr:
     repository: https://github.com/ansible-collections/frr.frr
     removal:
-      version: 11
+      major_version: 11
       reason: deprecated
       discussion: https://forum.ansible.com/t/6243
       announce_version: 10.2.0
@@ -192,7 +192,7 @@ collections:
       - Shilpi-J
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
     removal:
-      version: TBD
+      major_version: TBD
       reason: renamed
       new_name: ibm.storage_virtualize
   ibm.storage_virtualize:
@@ -218,7 +218,7 @@ collections:
       - ISIB-Group
     repository: https://github.com/ISIB-Group/inspur.sm
     removal:
-      version: 11
+      major_version: 11
       reason: considered-unmaintained
       discussion: https://forum.ansible.com/t/2854
       announce_version: 10.0.0a1
@@ -268,7 +268,7 @@ collections:
       - joshedmonds
     repository: https://github.com/ansible-collections/netapp.storagegrid
     removal:
-      version: 11
+      major_version: 11
       reason: considered-unmaintained
       discussion: https://forum.ansible.com/t/2811
       announce_version: 10.0.0a1
@@ -285,7 +285,7 @@ collections:
   openvswitch.openvswitch:
     repository: https://github.com/ansible-collections/openvswitch.openvswitch
     removal:
-      version: 11
+      major_version: 11
       reason: deprecated
       discussion: https://forum.ansible.com/t/6245
       announce_version: 10.2.0

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -184,6 +184,10 @@ collections:
     maintainers:
       - Shilpi-J
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
+    removal:
+      major_version: TBD
+      reason: renamed
+      new_name: ibm.storage_virtualize
   ibm.storage_virtualize:
     maintainers:
       - sumitguptaibm
@@ -234,8 +238,6 @@ collections:
       - wenjun666
       - chuyich
     repository: https://github.com/ansible-collections/netapp.cloudmanager
-  netapp_eseries.santricity:
-    repository: https://github.com/netapp-eseries/santricity
   netapp.ontap:
     maintainers:
       - carchi8py
@@ -243,6 +245,8 @@ collections:
       - wenjun666
       - chuyich
     repository: https://github.com/ansible-collections/netapp.ontap
+  netapp_eseries.santricity:
+    repository: https://github.com/netapp-eseries/santricity
   netbox.netbox:
     repository: https://github.com/netbox-community/ansible_modules
   ngine_io.cloudstack:
@@ -265,6 +269,12 @@ collections:
     repository: https://github.com/sensu/sensu-go-ansible
   splunk.es:
     repository: https://github.com/ansible-collections/splunk.es
+  t_systems_mms.icinga_director:
+    changelog-url: https://github.com/T-Systems-MMS/ansible-collection-icinga-director/blob/master/CHANGELOG.md
+    maintainers:
+      - rndmh3ro
+      - schurzi
+    repository: https://github.com/T-Systems-MMS/ansible-collection-icinga-director
   telekom_mms.icinga_director:
     changelog-url: https://github.com/telekom-mms/ansible-collection-icinga-director/blob/master/CHANGELOG.md
     maintainers:
@@ -273,12 +283,6 @@ collections:
     repository: https://github.com/telekom-mms/ansible-collection-icinga-director
   theforeman.foreman:
     repository: https://github.com/theforeman/foreman-ansible-modules
-  t_systems_mms.icinga_director:
-    changelog-url: https://github.com/T-Systems-MMS/ansible-collection-icinga-director/blob/master/CHANGELOG.md
-    maintainers:
-      - rndmh3ro
-      - schurzi
-    repository: https://github.com/T-Systems-MMS/ansible-collection-icinga-director
   vmware.vmware:
     maintainers:
       - machacekondra

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -69,6 +69,11 @@ collections:
     repository: https://github.com/ansible-collections/community.aws
   community.azure:
     repository: https://github.com/ansible-collections/community.azure
+    removal:
+      version: 10
+      reason: considered-unmaintained
+      discussion: https://github.com/ansible-community/community-topics/issues/263
+      announce_version: 9.0.0a1
   community.ciscosmb:
     maintainers:
       - qaxi
@@ -117,6 +122,11 @@ collections:
     maintainers:
       - rainerleber
     repository: https://github.com/ansible-collections/community.sap
+    removal:
+      version: 10
+      reason: renamed
+      new_name: community.sap_libs
+      announce_version: 9.0.0a1
   community.sap_libs:
     maintainers:
       - rainerleber
@@ -178,6 +188,11 @@ collections:
     repository: https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection
   frr.frr:
     repository: https://github.com/ansible-collections/frr.frr
+    removal:
+      version: 11
+      reason: deprecated
+      discussion: https://forum.ansible.com/t/6243
+      announce_version: 9.8.0
   gluster.gluster:
     repository: https://github.com/gluster/gluster-ansible-collection
   google.cloud:
@@ -194,12 +209,23 @@ collections:
       - datamattsson
     repository: https://github.com/hpe-storage/nimble-ansible-modules
     collection-directory: "./ansible_collection/hpe/nimble"
+    removal:
+      version: 10
+      reason: considered-unmaintained
+      discussion: https://github.com/ansible-community/community-topics/issues/254
+      announce_version: 9.0.0a1
   ibm.qradar:
     repository: https://github.com/ansible-collections/ibm.qradar
   ibm.spectrum_virtualize:
     maintainers:
       - Shilpi-J
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
+    removal:
+      version: TBD
+      reason: renamed
+      new_name: ibm.storage_virtualize
+      announce_version: 9.0.0b1
+      redirect_replacement_version: 10
   ibm.storage_virtualize:
     maintainers:
       - sumitguptaibm
@@ -222,6 +248,11 @@ collections:
     maintainers:
       - ISIB-Group
     repository: https://github.com/ISIB-Group/inspur.sm
+    removal:
+      version: 11
+      reason: considered-unmaintained
+      discussion: https://forum.ansible.com/t/2854
+      announce_version: 9.3.0
   junipernetworks.junos:
     repository: https://github.com/ansible-collections/junipernetworks.junos
   kaytus.ksmanage:
@@ -256,6 +287,11 @@ collections:
       - wenjun666
       - chuyich
     repository: https://github.com/ansible-collections/netapp.azure
+    removal:
+      version: 10
+      reason: considered-unmaintained
+      discussion: https://github.com/ansible-community/community-topics/issues/234
+      announce_version: 9.0.0a1
   netapp.cloudmanager:
     maintainers:
       - carchi8py
@@ -265,6 +301,11 @@ collections:
     repository: https://github.com/ansible-collections/netapp.cloudmanager
   netapp.elementsw:
     repository: https://github.com/ansible-collections/netapp.elementsw
+    removal:
+      version: 10
+      reason: considered-unmaintained
+      discussion: https://github.com/ansible-community/community-topics/issues/235
+      announce_version: 9.0.0a1
   netapp.ontap:
     maintainers:
       - carchi8py
@@ -278,6 +319,11 @@ collections:
       - jkandati
       - joshedmonds
     repository: https://github.com/ansible-collections/netapp.storagegrid
+    removal:
+      version: 11
+      reason: considered-unmaintained
+      discussion: https://forum.ansible.com/t/2811
+      announce_version: 9.3.0
   netapp.um_info:
     maintainers:
       - carchi8py
@@ -285,6 +331,11 @@ collections:
       - wenjun666
       - chuyich
     repository: https://github.com/ansible-collections/netapp.um_info
+    removal:
+      version: 10
+      reason: considered-unmaintained
+      discussion: https://github.com/ansible-community/community-topics/issues/244
+      announce_version: 9.0.0a1
   netapp_eseries.santricity:
     repository: https://github.com/netapp-eseries/santricity
   netbox.netbox:
@@ -297,6 +348,11 @@ collections:
     repository: https://opendev.org/openstack/ansible-collections-openstack
   openvswitch.openvswitch:
     repository: https://github.com/ansible-collections/openvswitch.openvswitch
+    removal:
+      version: 11
+      reason: deprecated
+      discussion: https://forum.ansible.com/t/6245
+      announce_version: 9.8.0
   ovirt.ovirt:
     repository: https://github.com/ovirt/ovirt-ansible-collection
     tag_version_regex: "^(.*)-1$"
@@ -308,6 +364,11 @@ collections:
     maintainers:
       - sdodsley
     repository: https://github.com/Pure-Storage-Ansible/Fusion-Collection
+    removal:
+      version: 10
+      reason: deprecated
+      discussion: https://forum.ansible.com/t/3712
+      announce_version: 9.3.0
   sensu.sensu_go:
     maintainers:
       - tadeboro
@@ -321,6 +382,11 @@ collections:
       - rndmh3ro
       - schurzi
     repository: https://github.com/T-Systems-MMS/ansible-collection-icinga-director
+    removal:
+      version: 10
+      reason: renamed
+      new_name: telekom_mms.icinga_director
+      announce_version: 9.0.0a1
   telekom_mms.icinga_director:
     changelog-url: https://github.com/telekom-mms/ansible-collection-icinga-director/blob/master/CHANGELOG.md
     maintainers:

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -70,7 +70,7 @@ collections:
   community.azure:
     repository: https://github.com/ansible-collections/community.azure
     removal:
-      version: 10
+      major_version: 10
       reason: considered-unmaintained
       discussion: https://github.com/ansible-community/community-topics/issues/263
       announce_version: 9.0.0a1
@@ -123,7 +123,7 @@ collections:
       - rainerleber
     repository: https://github.com/ansible-collections/community.sap
     removal:
-      version: 10
+      major_version: 10
       reason: renamed
       new_name: community.sap_libs
       announce_version: 9.0.0a1
@@ -189,7 +189,7 @@ collections:
   frr.frr:
     repository: https://github.com/ansible-collections/frr.frr
     removal:
-      version: 11
+      major_version: 11
       reason: deprecated
       discussion: https://forum.ansible.com/t/6243
       announce_version: 9.8.0
@@ -210,7 +210,7 @@ collections:
     repository: https://github.com/hpe-storage/nimble-ansible-modules
     collection-directory: "./ansible_collection/hpe/nimble"
     removal:
-      version: 10
+      major_version: 10
       reason: considered-unmaintained
       discussion: https://github.com/ansible-community/community-topics/issues/254
       announce_version: 9.0.0a1
@@ -221,11 +221,11 @@ collections:
       - Shilpi-J
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
     removal:
-      version: TBD
+      major_version: TBD
       reason: renamed
       new_name: ibm.storage_virtualize
       announce_version: 9.0.0b1
-      redirect_replacement_version: 10
+      redirect_replacement_major_version: 10
   ibm.storage_virtualize:
     maintainers:
       - sumitguptaibm
@@ -249,7 +249,7 @@ collections:
       - ISIB-Group
     repository: https://github.com/ISIB-Group/inspur.sm
     removal:
-      version: 11
+      major_version: 11
       reason: considered-unmaintained
       discussion: https://forum.ansible.com/t/2854
       announce_version: 9.3.0
@@ -288,7 +288,7 @@ collections:
       - chuyich
     repository: https://github.com/ansible-collections/netapp.azure
     removal:
-      version: 10
+      major_version: 10
       reason: considered-unmaintained
       discussion: https://github.com/ansible-community/community-topics/issues/234
       announce_version: 9.0.0a1
@@ -302,7 +302,7 @@ collections:
   netapp.elementsw:
     repository: https://github.com/ansible-collections/netapp.elementsw
     removal:
-      version: 10
+      major_version: 10
       reason: considered-unmaintained
       discussion: https://github.com/ansible-community/community-topics/issues/235
       announce_version: 9.0.0a1
@@ -320,7 +320,7 @@ collections:
       - joshedmonds
     repository: https://github.com/ansible-collections/netapp.storagegrid
     removal:
-      version: 11
+      major_version: 11
       reason: considered-unmaintained
       discussion: https://forum.ansible.com/t/2811
       announce_version: 9.3.0
@@ -332,7 +332,7 @@ collections:
       - chuyich
     repository: https://github.com/ansible-collections/netapp.um_info
     removal:
-      version: 10
+      major_version: 10
       reason: considered-unmaintained
       discussion: https://github.com/ansible-community/community-topics/issues/244
       announce_version: 9.0.0a1
@@ -349,7 +349,7 @@ collections:
   openvswitch.openvswitch:
     repository: https://github.com/ansible-collections/openvswitch.openvswitch
     removal:
-      version: 11
+      major_version: 11
       reason: deprecated
       discussion: https://forum.ansible.com/t/6245
       announce_version: 9.8.0
@@ -365,7 +365,7 @@ collections:
       - sdodsley
     repository: https://github.com/Pure-Storage-Ansible/Fusion-Collection
     removal:
-      version: 10
+      major_version: 10
       reason: deprecated
       discussion: https://forum.ansible.com/t/3712
       announce_version: 9.3.0
@@ -383,7 +383,7 @@ collections:
       - schurzi
     repository: https://github.com/T-Systems-MMS/ansible-collection-icinga-director
     removal:
-      version: 10
+      major_version: 10
       reason: renamed
       new_name: telekom_mms.icinga_director
       announce_version: 9.0.0a1


### PR DESCRIPTION
This is necessary to implement https://github.com/ansible-community/antsibull-docs/issues/93.

Basically there are four ways in this PR that mark a collection for removal. I've added three further possibilities below:

1. It is considered unmaintained:
    ```yaml
    removal:
      version: 11
      reason: considered-unmaintained
      discussion: https://forum.ansible.com/...
      announce_version: 9.3.0
    ```
2. It has officially been deprecated:
    ```yaml
    removal:
      version: 11
      reason: deprecated
      discussion: https://forum.ansible.com/...
      announce_version: 9.3.0
    ```
3. It has been renamed (new name provided) and the removal version is known:
    ```yaml
    removal:
      version: 10
      reason: renamed
      new_name: namespace.name
      announce_version: 9.3.0
    ```
4. It has been renamed (new name provided) and the removal version is not yet known:
    ```yaml
    removal:
      version: TBD
      reason: renamed
      new_name: namespace.name
      announce_version: 9.3.0
    ```
5. (Not yet in use.) It is broken and no longer works with modern versions of Ansible:
    ```yaml
    removal:
      version: 11
      reason: broken
      discussion: https://forum.ansible.com/...
      announce_version: 9.3.0
    ```
6. (Not yet in use.) Removed for violations of the inclusion rules:
    ```yaml
    removal:
      version: 11
      reason: inclusion-rules-violation
      discussion: https://forum.ansible.com/...
      announce_version: 9.3.0
    ```
7. (Not yet in use.) Other:
    ```yaml
    removal:
      version: 11
      reason: other
      reason_text: The collection wasn't cow friendly, so the Steering Committee decided to kick it out.
      discussion: https://forum.ansible.com/...
      announce_version: 9.3.0
    ```

What do you think? That should cover all cases in https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html (if I didn't forgot about something), and there's the free-form version (`reason: other` / `reason_text: ...`) for other cases.