### PR TITLE
all collection-meta: remove collection-directory for wti.remote

### DIFF
--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -321,4 +321,3 @@ collections:
     repository: https://github.com/ansible-collections/vyos.vyos
   wti.remote:
     repository: https://github.com/wtinetworkgear/wti-collection
-    collection-directory: "./wti/remote"

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -307,4 +307,3 @@ collections:
     repository: https://github.com/ansible-collections/vyos.vyos
   wti.remote:
     repository: https://github.com/wtinetworkgear/wti-collection
-    collection-directory: "./wti/remote"

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -357,4 +357,3 @@ collections:
     repository: https://github.com/ansible-collections/vyos.vyos
   wti.remote:
     repository: https://github.com/wtinetworkgear/wti-collection
-    collection-directory: "./wti/remote"


### PR DESCRIPTION
The wti.remote collection uses the standard flat layout as of v1.0.9.