### PR TITLE
Deprecate frr.frr

### DIFF
--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -134,3 +134,11 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2024-09-10'
+  10.5.0:
+    changes:
+      deprecated_features:
+      - The ``frr.frr`` collection has been deprecated by the maintainers. Since they've
+        also announced to not support ansible-core 2.18, it will be removed from Ansible
+        11 if no one starts maintaining it again before Ansible 11. See `the removal
+        process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
+        (https://forum.ansible.com/t/6243).

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -172,6 +172,11 @@ collections:
     repository: https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection
   frr.frr:
     repository: https://github.com/ansible-collections/frr.frr
+    removal:
+      major_version: 11
+      reason: deprecated
+      discussion: https://forum.ansible.com/t/6243
+      announce_version: 10.5.0
   google.cloud:
     repository: https://github.com/ansible-collections/google.cloud
   grafana.grafana:


### PR DESCRIPTION
This is just meant as an example how to deprecate a collection in the Ansible Community Package.