### PR TITLE
Automatically generate collection deprecation changelog entries from metadata

### DIFF
--- a/10/CHANGELOG-v10.md
+++ b/10/CHANGELOG-v10.md
@@ -1585,8 +1585,12 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 <a id="deprecated-features-2"></a>
 ### Deprecated Features
 
-* The <code>frr\.frr</code> collection has been deprecated by the maintainers\. Since they\'ve also announced to not support ansible\-core 2\.18\, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\. See [the removal process for details on how this works](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#canceling\-removal\-of\-an\-unmaintained\-collection) \([https\://forum\.ansible\.com/t/6243](https\://forum\.ansible\.com/t/6243)\)\.
-* The <code>openvswitch\.openvswitch</code> collection has been deprecated by the maintainers\. Since they\'ve also announced to not support ansible\-core 2\.18\, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\. See [the removal process for details on how this works](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#canceling\-removal\-of\-an\-unmaintained\-collection) \([https\://forum\.ansible\.com/t/6245](https\://forum\.ansible\.com/t/6245)\)\.
+* The <code>frr\.frr</code> collection has been deprecated\.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details \([https\://forum\.ansible\.com/t/6243](https\://forum\.ansible\.com/t/6243)\)\.
+* The <code>openvswitch\.openvswitch</code> collection has been deprecated\.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details \([https\://forum\.ansible\.com/t/6245](https\://forum\.ansible\.com/t/6245)\)\.
 
 <a id="bugfixes-2"></a>
 ### Bugfixes
@@ -4229,8 +4233,10 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 <a id="deprecated-features-4"></a>
 ### Deprecated Features
 
-* The <code>inspur\.sm</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\. See [the removal process for details on how this works](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#cancelling\-removal\-of\-an\-unmaintained\-collection) \([https\://forum\.ansible\.com/t/2854](https\://forum\.ansible\.com/t/2854)\)\.
-* The <code>netapp\.storagegrid</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\. See [the removal process for details on how this works](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#cancelling\-removal\-of\-an\-unmaintained\-collection) \([https\://forum\.ansible\.com/t/2811](https\://forum\.ansible\.com/t/2811)\)\.
+* The <code>inspur\.sm</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/2854](https\://forum\.ansible\.com/t/2854)\)\.
+* The <code>netapp\.storagegrid</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/2811](https\://forum\.ansible\.com/t/2811)\)\.
 
 <a id="ansible-core-15"></a>
 #### Ansible\-core
@@ -4329,14 +4335,20 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 <a id="removed-features-previously-deprecated"></a>
 ### Removed Features \(previously deprecated\)
 
-* The <code>gluster\.gluster</code> collection was considered unmaintained and removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/225](https\://github\.com/ansible\-community/community\-topics/issues/225)\)\. Users can still install this collection with <code>ansible\-galaxy collection install gluster\.gluster</code>\.
-* The <code>hpe\.nimble</code> collection was considered unmaintained and removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/254](https\://github\.com/ansible\-community/community\-topics/issues/254)\)\. Users can still install this collection with <code>ansible\-galaxy collection install hpe\.nimble</code>\.
-* The <code>netapp\.aws</code> collection was considered unmaintained and removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/223](https\://github\.com/ansible\-community/community\-topics/issues/223)\)\. Users can still install this collection with <code>ansible\-galaxy collection install netapp\.aws</code>\.
-* The <code>netapp\.azure</code> collection was considered unmaintained and removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/234](https\://github\.com/ansible\-community/community\-topics/issues/234)\)\. Users can still install this collection with <code>ansible\-galaxy collection install netapp\.azure</code>\.
-* The <code>netapp\.elementsw</code> collection was considered unmaintained and removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/235](https\://github\.com/ansible\-community/community\-topics/issues/235)\)\. Users can still install this collection with <code>ansible\-galaxy collection install netapp\.elementsw</code>\.
-* The <code>netapp\.um\_info</code> collection was considered unmaintained and removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/244](https\://github\.com/ansible\-community/community\-topics/issues/244)\)\. Users can still install this collection with <code>ansible\-galaxy collection install netapp\.um\_info</code>\.
-* The deprecated <code>community\.azure</code> collection has been removed\. There is a successor collection <code>azure\.azcollection</code> in the community package which should cover the same functionality\.
-* The deprecated <code>community\.sap</code> collection has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/247](https\://github\.com/ansible\-community/community\-topics/issues/247)\)\. There is a successor collection <code>community\.sap\_libs</code> in the community package which should cover the same functionality\.
+* The <code>community\.azure</code> collection was considered unmaintained and has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/263](https\://github\.com/ansible\-community/community\-topics/issues/263)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install community\.azure</code>\.
+* The <code>hpe\.nimble</code> collection was considered unmaintained and has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/254](https\://github\.com/ansible\-community/community\-topics/issues/254)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install hpe\.nimble</code>\.
+* The <code>netapp\.azure</code> collection was considered unmaintained and has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/234](https\://github\.com/ansible\-community/community\-topics/issues/234)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install netapp\.azure</code>\.
+* The <code>netapp\.elementsw</code> collection was considered unmaintained and has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/235](https\://github\.com/ansible\-community/community\-topics/issues/235)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install netapp\.elementsw</code>\.
+* The <code>netapp\.um\_info</code> collection was considered unmaintained and has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/244](https\://github\.com/ansible\-community/community\-topics/issues/244)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install netapp\.um\_info</code>\.
+* The collection <code>community\.sap</code> has been completely removed from Ansible\.
+  It has been renamed to <code>community\.sap\_libs</code>\.
+  The collection will be completely removed from Ansible eventually\.
+  Please update your FQCNs from <code>community\.sap</code> to <code>community\.sap\_libs</code>\.
 * The deprecated <code>purestorage\.fusion</code> collection has been removed \([https\://forum\.ansible\.com/t/3712](https\://forum\.ansible\.com/t/3712)\)\.
 
 <a id="ansible-core-16"></a>

--- a/10/CHANGELOG-v10.rst
+++ b/10/CHANGELOG-v10.rst
@@ -1448,8 +1448,12 @@ purestorage.flasharray
 Deprecated Features
 -------------------
 
-- The ``frr.frr`` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/6243).
-- The ``openvswitch.openvswitch`` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/6245).
+- The ``frr.frr`` collection has been deprecated.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/6243 <https://forum.ansible.com/t/6243>`__).
+- The ``openvswitch.openvswitch`` collection has been deprecated.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/6245 <https://forum.ansible.com/t/6245>`__).
 
 Bugfixes
 --------
@@ -3922,8 +3926,10 @@ vmware.vmware_rest
 Deprecated Features
 -------------------
 
-- The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/2854).
-- The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/2811).
+- The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2854 <https://forum.ansible.com/t/2854>`__).
+- The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2811 <https://forum.ansible.com/t/2811>`__).
 
 Ansible-core
 ~~~~~~~~~~~~
@@ -4022,15 +4028,21 @@ kubernetes.core
 Removed Features (previously deprecated)
 ----------------------------------------
 
-- The ``gluster.gluster`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/225). Users can still install this collection with ``ansible-galaxy collection install gluster.gluster``.
-- The ``hpe.nimble`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/254). Users can still install this collection with ``ansible-galaxy collection install hpe.nimble``.
-- The ``netapp.aws`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/223). Users can still install this collection with ``ansible-galaxy collection install netapp.aws``.
-- The ``netapp.azure`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/234). Users can still install this collection with ``ansible-galaxy collection install netapp.azure``.
-- The ``netapp.elementsw`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/235). Users can still install this collection with ``ansible-galaxy collection install netapp.elementsw``.
-- The ``netapp.um_info`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/244). Users can still install this collection with ``ansible-galaxy collection install netapp.um_info``.
-- The deprecated ``community.azure`` collection has been removed. There is a successor collection ``azure.azcollection`` in the community package which should cover the same functionality.
-- The deprecated ``community.sap`` collection has been removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/247). There is a successor collection ``community.sap_libs`` in the community package which should cover the same functionality.
-- The deprecated ``purestorage.fusion`` collection has been removed (https://forum.ansible.com/t/3712).
+- The ``community.azure`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/263 <https://github.com/ansible-community/community-topics/issues/263>`__).
+  Users can still install this collection with ``ansible-galaxy collection install community.azure``.
+- The ``hpe.nimble`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/254 <https://github.com/ansible-community/community-topics/issues/254>`__).
+  Users can still install this collection with ``ansible-galaxy collection install hpe.nimble``.
+- The ``netapp.azure`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/234 <https://github.com/ansible-community/community-topics/issues/234>`__).
+  Users can still install this collection with ``ansible-galaxy collection install netapp.azure``.
+- The ``netapp.elementsw`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/235 <https://github.com/ansible-community/community-topics/issues/235>`__).
+  Users can still install this collection with ``ansible-galaxy collection install netapp.elementsw``.
+- The ``netapp.um_info`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/244 <https://github.com/ansible-community/community-topics/issues/244>`__).
+  Users can still install this collection with ``ansible-galaxy collection install netapp.um_info``.
+- The collection ``community.sap`` has been completely removed from Ansible.
+  It has been renamed to ``community.sap_libs``.
+  The collection will be completely removed from Ansible eventually.
+  Please update your FQCNs from ``community.sap`` to ``community.sap_libs``.
+- The deprecated ``purestorage.fusion`` collection has been removed (`https://forum.ansible.com/t/3712 <https://forum.ansible.com/t/3712>`__).
 
 Ansible-core
 ~~~~~~~~~~~~

--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -9,52 +9,10 @@ releases:
     release_date: '2024-06-04'
   10.0.0a1:
     changes:
-      deprecated_features:
-      - The ``inspur.sm`` collection is considered unmaintained and will be removed
-        from Ansible 11 if no one starts maintaining it again before Ansible 11. See
-        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
-        (https://forum.ansible.com/t/2854).
-      - The ``netapp.storagegrid`` collection is considered unmaintained and will
-        be removed from Ansible 11 if no one starts maintaining it again before Ansible
-        11. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
-        (https://forum.ansible.com/t/2811).
       release_summary: 'Release Date: 2024-04-09
 
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
-      removed_features:
-      - The ``gluster.gluster`` collection was considered unmaintained and removed
-        from Ansible 10 (https://github.com/ansible-community/community-topics/issues/225).
-        Users can still install this collection with ``ansible-galaxy collection install
-        gluster.gluster``.
-      - The ``hpe.nimble`` collection was considered unmaintained and removed from
-        Ansible 10 (https://github.com/ansible-community/community-topics/issues/254).
-        Users can still install this collection with ``ansible-galaxy collection install
-        hpe.nimble``.
-      - The ``netapp.aws`` collection was considered unmaintained and removed from
-        Ansible 10 (https://github.com/ansible-community/community-topics/issues/223).
-        Users can still install this collection with ``ansible-galaxy collection install
-        netapp.aws``.
-      - The ``netapp.azure`` collection was considered unmaintained and removed from
-        Ansible 10 (https://github.com/ansible-community/community-topics/issues/234).
-        Users can still install this collection with ``ansible-galaxy collection install
-        netapp.azure``.
-      - The ``netapp.elementsw`` collection was considered unmaintained and removed
-        from Ansible 10 (https://github.com/ansible-community/community-topics/issues/235).
-        Users can still install this collection with ``ansible-galaxy collection install
-        netapp.elementsw``.
-      - The ``netapp.um_info`` collection was considered unmaintained and removed
-        from Ansible 10 (https://github.com/ansible-community/community-topics/issues/244).
-        Users can still install this collection with ``ansible-galaxy collection install
-        netapp.um_info``.
-      - The deprecated ``community.azure`` collection has been removed. There is a
-        successor collection ``azure.azcollection`` in the community package which
-        should cover the same functionality.
-      - The deprecated ``community.sap`` collection has been removed from Ansible
-        10 (https://github.com/ansible-community/community-topics/issues/247). There
-        is a successor collection ``community.sap_libs`` in the community package
-        which should cover the same functionality.
-      - The deprecated ``purestorage.fusion`` collection has been removed (https://forum.ansible.com/t/3712).
     release_date: '2024-04-09'
   10.0.0a2:
     changes:
@@ -104,17 +62,6 @@ releases:
     release_date: '2024-06-18'
   10.2.0:
     changes:
-      deprecated_features:
-      - The ``frr.frr`` collection has been deprecated by the maintainers. Since they've
-        also announced to not support ansible-core 2.18, it will be removed from Ansible
-        11 if no one starts maintaining it again before Ansible 11. See `the removal
-        process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
-        (https://forum.ansible.com/t/6243).
-      - The ``openvswitch.openvswitch`` collection has been deprecated by the maintainers.
-        Since they've also announced to not support ansible-core 2.18, it will be
-        removed from Ansible 11 if no one starts maintaining it again before Ansible
-        11. See `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
-        (https://forum.ansible.com/t/6245).
       release_summary: 'Release Date: 2024-07-16
 
 
@@ -134,19 +81,3 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2024-09-10'
-  10.5.0:
-    changes:
-      deprecated_features:
-      - The collection ``t_systems_mms.icinga_director`` has been renamed to ``telekom_mms.icinga_director``.
-        For now both collections are included in Ansible. The content in ``t_systems_mms.icinga_director``
-        has been replaced with deprecated redirects to the new collection in Ansible
-        9.0.0, and these redirects will be removed from Ansible 11. Please update
-        your FQCNs from ``t_systems_mms.icinga_director`` to ``telekom_mms.icinga_director``.
-      - The ``ngine_io.exoscale`` collection has been deprecated by the maintainers. Since they've
-        also announced that the collection does not work anymore with the Cloudstack API after May 1, 2024,
-        it will be removed from Ansible 11
-        (https://forum.ansible.com/t/2572).
-      - The ``sensu.sensu_go`` collection will be removed from Ansible 12 due
-        to unresolved Ansible inclusion requirements violations
-        (https://forum.ansible.com/t/8380).
-        See `the removal process for details on how this works and can be cancelled <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__.

--- a/10/porting_guide_10.rst
+++ b/10/porting_guide_10.rst
@@ -261,8 +261,12 @@ grafana.grafana
 Deprecated Features
 -------------------
 
-- The ``frr.frr`` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/6243).
-- The ``openvswitch.openvswitch`` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/6245).
+- The ``frr.frr`` collection has been deprecated.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/6243 <https://forum.ansible.com/t/6243>`__).
+- The ``openvswitch.openvswitch`` collection has been deprecated.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/6245 <https://forum.ansible.com/t/6245>`__).
 
 Porting Guide for v10.1.0
 =========================
@@ -621,15 +625,21 @@ Removed Collections
 Removed Features
 ----------------
 
-- The ``gluster.gluster`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/225). Users can still install this collection with ``ansible-galaxy collection install gluster.gluster``.
-- The ``hpe.nimble`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/254). Users can still install this collection with ``ansible-galaxy collection install hpe.nimble``.
-- The ``netapp.aws`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/223). Users can still install this collection with ``ansible-galaxy collection install netapp.aws``.
-- The ``netapp.azure`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/234). Users can still install this collection with ``ansible-galaxy collection install netapp.azure``.
-- The ``netapp.elementsw`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/235). Users can still install this collection with ``ansible-galaxy collection install netapp.elementsw``.
-- The ``netapp.um_info`` collection was considered unmaintained and removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/244). Users can still install this collection with ``ansible-galaxy collection install netapp.um_info``.
-- The deprecated ``community.azure`` collection has been removed. There is a successor collection ``azure.azcollection`` in the community package which should cover the same functionality.
-- The deprecated ``community.sap`` collection has been removed from Ansible 10 (https://github.com/ansible-community/community-topics/issues/247). There is a successor collection ``community.sap_libs`` in the community package which should cover the same functionality.
-- The deprecated ``purestorage.fusion`` collection has been removed (https://forum.ansible.com/t/3712).
+- The ``community.azure`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/263 <https://github.com/ansible-community/community-topics/issues/263>`__).
+  Users can still install this collection with ``ansible-galaxy collection install community.azure``.
+- The ``hpe.nimble`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/254 <https://github.com/ansible-community/community-topics/issues/254>`__).
+  Users can still install this collection with ``ansible-galaxy collection install hpe.nimble``.
+- The ``netapp.azure`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/234 <https://github.com/ansible-community/community-topics/issues/234>`__).
+  Users can still install this collection with ``ansible-galaxy collection install netapp.azure``.
+- The ``netapp.elementsw`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/235 <https://github.com/ansible-community/community-topics/issues/235>`__).
+  Users can still install this collection with ``ansible-galaxy collection install netapp.elementsw``.
+- The ``netapp.um_info`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/244 <https://github.com/ansible-community/community-topics/issues/244>`__).
+  Users can still install this collection with ``ansible-galaxy collection install netapp.um_info``.
+- The collection ``community.sap`` has been completely removed from Ansible.
+  It has been renamed to ``community.sap_libs``.
+  The collection will be completely removed from Ansible eventually.
+  Please update your FQCNs from ``community.sap`` to ``community.sap_libs``.
+- The deprecated ``purestorage.fusion`` collection has been removed (`https://forum.ansible.com/t/3712 <https://forum.ansible.com/t/3712>`__).
 
 Ansible-core
 ~~~~~~~~~~~~
@@ -715,8 +725,10 @@ junipernetworks.junos
 Deprecated Features
 -------------------
 
-- The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/2854).
-- The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/2811).
+- The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2854 <https://forum.ansible.com/t/2854>`__).
+- The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2811 <https://forum.ansible.com/t/2811>`__).
 
 Ansible-core
 ~~~~~~~~~~~~

--- a/11/CHANGELOG-v11.md
+++ b/11/CHANGELOG-v11.md
@@ -1356,10 +1356,16 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 <a id="removed-features-previously-deprecated"></a>
 ### Removed Features \(previously deprecated\)
 
-* The <code>frr\.frr</code> collection has been removed because it does not support ansible\-core 2\.18 \([https\://forum\.ansible\.com/t/6243](https\://forum\.ansible\.com/t/6243)\)\.
-* The <code>inspur\.sm</code> collection was considered unmaintained and removed from Ansible 11 \([https\://forum\.ansible\.com/t/2854](https\://forum\.ansible\.com/t/2854)\)\. Users can still install this collection with <code>ansible\-galaxy collection install inspur\.sm</code>\.
-* The <code>netapp\.storagegrid</code> collection was considered unmaintained and removed from Ansible 11 \([https\://forum\.ansible\.com/t/2811](https\://forum\.ansible\.com/t/2811)\)\. Users can still install this collection with <code>ansible\-galaxy collection install netapp\.storagegrid</code>\.
-* The <code>openvswitch\.openvswitch</code> collection has been removed because it does not support ansible\-core 2\.18 \([https\://forum\.ansible\.com/t/6245](https\://forum\.ansible\.com/t/6245)\)\.
+* The <code>inspur\.sm</code> collection was considered unmaintained and has been removed from Ansible 11 \([https\://forum\.ansible\.com/t/2854](https\://forum\.ansible\.com/t/2854)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install inspur\.sm</code>\.
+* The <code>netapp\.storagegrid</code> collection was considered unmaintained and has been removed from Ansible 11 \([https\://forum\.ansible\.com/t/2811](https\://forum\.ansible\.com/t/2811)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install netapp\.storagegrid</code>\.
+* The collection <code>t\_systems\_mms\.icinga\_director</code> has been completely removed from Ansible\.
+  It has been renamed to <code>telekom\_mms\.icinga\_director</code>\.
+  <code>t\_systems\_mms\.icinga\_director</code> has been replaced by deprecated redirects to <code>telekom\_mms\.icinga\_director</code> in Ansible 9\.0\.0\.
+  Please update your FQCNs from <code>t\_systems\_mms\.icinga\_director</code> to <code>telekom\_mms\.icinga\_director</code>\.
+* The deprecated <code>frr\.frr</code> collection has been removed \([https\://forum\.ansible\.com/t/6243](https\://forum\.ansible\.com/t/6243)\)\.
+* The deprecated <code>openvswitch\.openvswitch</code> collection has been removed \([https\://forum\.ansible\.com/t/6245](https\://forum\.ansible\.com/t/6245)\)\.
 
 <a id="ansible-core-4"></a>
 #### Ansible\-core

--- a/11/CHANGELOG-v11.rst
+++ b/11/CHANGELOG-v11.rst
@@ -1248,10 +1248,16 @@ community.vmware
 Removed Features (previously deprecated)
 ----------------------------------------
 
-- The ``frr.frr`` collection has been removed because it does not support ansible-core 2.18 (https://forum.ansible.com/t/6243).
-- The ``inspur.sm`` collection was considered unmaintained and removed from Ansible 11 (https://forum.ansible.com/t/2854). Users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
-- The ``netapp.storagegrid`` collection was considered unmaintained and removed from Ansible 11 (https://forum.ansible.com/t/2811). Users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
-- The ``openvswitch.openvswitch`` collection has been removed because it does not support ansible-core 2.18 (https://forum.ansible.com/t/6245).
+- The ``inspur.sm`` collection was considered unmaintained and has been removed from Ansible 11 (`https://forum.ansible.com/t/2854 <https://forum.ansible.com/t/2854>`__).
+  Users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
+- The ``netapp.storagegrid`` collection was considered unmaintained and has been removed from Ansible 11 (`https://forum.ansible.com/t/2811 <https://forum.ansible.com/t/2811>`__).
+  Users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
+- The collection ``t_systems_mms.icinga_director`` has been completely removed from Ansible.
+  It has been renamed to ``telekom_mms.icinga_director``.
+  ``t_systems_mms.icinga_director`` has been replaced by deprecated redirects to ``telekom_mms.icinga_director`` in Ansible 9.0.0.
+  Please update your FQCNs from ``t_systems_mms.icinga_director`` to ``telekom_mms.icinga_director``.
+- The deprecated ``frr.frr`` collection has been removed (`https://forum.ansible.com/t/6243 <https://forum.ansible.com/t/6243>`__).
+- The deprecated ``openvswitch.openvswitch`` collection has been removed (`https://forum.ansible.com/t/6245 <https://forum.ansible.com/t/6245>`__).
 
 Ansible-core
 ~~~~~~~~~~~~

--- a/11/changelog.yaml
+++ b/11/changelog.yaml
@@ -6,25 +6,4 @@ releases:
 
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
-      removed_features:
-      - The ``frr.frr`` collection has been removed because it does not support ansible-core 2.18
-        (https://forum.ansible.com/t/6243).
-      - The ``inspur.sm`` collection was considered unmaintained and removed from
-        Ansible 11 (https://forum.ansible.com/t/2854). Users can still install this
-        collection with ``ansible-galaxy collection install inspur.sm``.
-      - The ``netapp.storagegrid`` collection was considered unmaintained and removed
-        from Ansible 11 (https://forum.ansible.com/t/2811). Users can still install
-        this collection with ``ansible-galaxy collection install netapp.storagegrid``.
-      - The ``openvswitch.openvswitch`` collection has been removed because it does
-        not support ansible-core 2.18 (https://forum.ansible.com/t/6245).
     release_date: '2024-09-25'
-  11.0.0a2:
-    changes:
-      removed_features:
-      - The ``ngine_io.exoscale`` collection has been removed because it has been deprecated by its maintainers
-        (https://forum.ansible.com/t/2572).
-      deprecated_features:
-      - The ``sensu.sensu_go`` collection will be removed from Ansible 12 due
-        to unresolved Ansible inclusion requirements violations
-        (https://forum.ansible.com/t/8380).
-        See `the removal process for details on how this works and can be cancelled <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__.

--- a/11/porting_guide_11.rst
+++ b/11/porting_guide_11.rst
@@ -254,10 +254,16 @@ Removed Collections
 Removed Features
 ----------------
 
-- The ``frr.frr`` collection has been removed because it does not support ansible-core 2.18 (https://forum.ansible.com/t/6243).
-- The ``inspur.sm`` collection was considered unmaintained and removed from Ansible 11 (https://forum.ansible.com/t/2854). Users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
-- The ``netapp.storagegrid`` collection was considered unmaintained and removed from Ansible 11 (https://forum.ansible.com/t/2811). Users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
-- The ``openvswitch.openvswitch`` collection has been removed because it does not support ansible-core 2.18 (https://forum.ansible.com/t/6245).
+- The ``inspur.sm`` collection was considered unmaintained and has been removed from Ansible 11 (`https://forum.ansible.com/t/2854 <https://forum.ansible.com/t/2854>`__).
+  Users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
+- The ``netapp.storagegrid`` collection was considered unmaintained and has been removed from Ansible 11 (`https://forum.ansible.com/t/2811 <https://forum.ansible.com/t/2811>`__).
+  Users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
+- The collection ``t_systems_mms.icinga_director`` has been completely removed from Ansible.
+  It has been renamed to ``telekom_mms.icinga_director``.
+  ``t_systems_mms.icinga_director`` has been replaced by deprecated redirects to ``telekom_mms.icinga_director`` in Ansible 9.0.0.
+  Please update your FQCNs from ``t_systems_mms.icinga_director`` to ``telekom_mms.icinga_director``.
+- The deprecated ``frr.frr`` collection has been removed (`https://forum.ansible.com/t/6243 <https://forum.ansible.com/t/6243>`__).
+- The deprecated ``openvswitch.openvswitch`` collection has been removed (`https://forum.ansible.com/t/6245 <https://forum.ansible.com/t/6245>`__).
 
 Ansible-core
 ~~~~~~~~~~~~

--- a/9/CHANGELOG-v9.md
+++ b/9/CHANGELOG-v9.md
@@ -1350,8 +1350,12 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 <a id="deprecated-features-2"></a>
 ### Deprecated Features
 
-* The <code>frr\.frr</code> collection has been deprecated by the maintainers\. Since they\'ve also announced to not support ansible\-core 2\.18\, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\. See [the removal process for details on how this works](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#canceling\-removal\-of\-an\-unmaintained\-collection) \([https\://forum\.ansible\.com/t/6243](https\://forum\.ansible\.com/t/6243)\)\.
-* The <code>openvswitch\.openvswitch</code> collection has been deprecated by the maintainers\. Since they\'ve also announced to not support ansible\-core 2\.18\, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\. See [the removal process for details on how this works](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#canceling\-removal\-of\-an\-unmaintained\-collection) \([https\://forum\.ansible\.com/t/6245](https\://forum\.ansible\.com/t/6245)\)\.
+* The <code>frr\.frr</code> collection has been deprecated\.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details \([https\://forum\.ansible\.com/t/6243](https\://forum\.ansible\.com/t/6243)\)\.
+* The <code>openvswitch\.openvswitch</code> collection has been deprecated\.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details \([https\://forum\.ansible\.com/t/6245](https\://forum\.ansible\.com/t/6245)\)\.
 
 <a id="bugfixes-2"></a>
 ### Bugfixes
@@ -4095,9 +4099,13 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 <a id="deprecated-features-6"></a>
 ### Deprecated Features
 
-* The <code>inspur\.sm</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\. See [the removal process for details on how this works](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#cancelling\-removal\-of\-an\-unmaintained\-collection) \([https\://forum\.ansible\.com/t/2854](https\://forum\.ansible\.com/t/2854)\)\.
-* The <code>netapp\.storagegrid</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\. See [the removal process for details on how this works](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#cancelling\-removal\-of\-an\-unmaintained\-collection) \([https\://forum\.ansible\.com/t/2811](https\://forum\.ansible\.com/t/2811)\)\.
-* The <code>purestorage\.fusion</code> collection is officially unmaintained and has been archived\. Therefore\, it will be removed from Ansible 10 \([https\://forum\.ansible\.com/t/3712](https\://forum\.ansible\.com/t/3712)\)\.
+* The <code>inspur\.sm</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/2854](https\://forum\.ansible\.com/t/2854)\)\.
+* The <code>netapp\.storagegrid</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/2811](https\://forum\.ansible\.com/t/2811)\)\.
+* The <code>purestorage\.fusion</code> collection has been deprecated\.
+  It will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details \([https\://forum\.ansible\.com/t/3712](https\://forum\.ansible\.com/t/3712)\)\.
 
 <a id="community-crypto-12"></a>
 #### community\.crypto
@@ -7950,14 +7958,30 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 <a id="deprecated-features-8"></a>
 ### Deprecated Features
 
-* The <code>community\.azure</code> collection is officially unmaintained and has been archived\. Therefore\, it will be removed from Ansible 10\. There is already a successor collection <code>azure\.azcollection</code> in the community package which should cover the same functionality \([https\://github\.com/ansible\-community/community\-topics/issues/263](https\://github\.com/ansible\-community/community\-topics/issues/263)\)\.
-* The <code>hpe\.nimble</code> collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\. See [the removal process for details on how this works](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#cancelling\-removal\-of\-an\-unmaintained\-collection) \([https\://github\.com/ansible\-community/community\-topics/issues/254](https\://github\.com/ansible\-community/community\-topics/issues/254)\)\.
-* The collection <code>community\.sap</code> has been renamed to <code>community\.sap\_libs</code>\. For now both collections are included in Ansible\. The content in <code>community\.sap</code> has deprecated redirects to the new collection in Ansible 9\.0\.0\, and the collection will be removed from Ansible 10 completely\. Please update your FQCNs for <code>community\.sap</code>\.
-* The collection <code>ibm\.spectrum\_virtualize</code> has been renamed to <code>ibm\.storage\_virtualize</code>\. For now\, both collections are included in Ansible\. The content in <code>ibm\.spectrum\_virtualize</code> will be replaced with deprecated redirects to the new collection in Ansible 10\.0\.0\, and these redirects will eventually be removed from Ansible\. Please update your FQCNs for <code>ibm\.spectrum\_virtualize</code>\.
-* The collection <code>t\_systems\_mms\.icinga\_director</code> has been renamed to <code>telekom\_mms\.icinga\_director</code>\. For now both collections are included in Ansible\. The content in <code>t\_systems\_mms\.icinga\_director</code> has been replaced with deprecated redirects to the new collection in Ansible 9\.0\.0\, and these redirects will be removed from Ansible 11\. Please update your FQCNs for <code>t\_systems\_mms\.icinga\_director</code>\.
-* The netapp\.azure collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\. See [the removal process for details on how this works](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#cancelling\-removal\-of\-an\-unmaintained\-collection) \([https\://github\.com/ansible\-community/community\-topics/issues/234](https\://github\.com/ansible\-community/community\-topics/issues/234)\)\.
-* The netapp\.elementsw collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\. See [the removal process for details on how this works](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#cancelling\-removal\-of\-an\-unmaintained\-collection) \([https\://github\.com/ansible\-community/community\-topics/issues/235](https\://github\.com/ansible\-community/community\-topics/issues/235)\)\.
-* The netapp\.um\_info collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\. See [the removal process for details on how this works](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#cancelling\-removal\-of\-an\-unmaintained\-collection) \([https\://github\.com/ansible\-community/community\-topics/issues/244](https\://github\.com/ansible\-community/community\-topics/issues/244)\)\.
+* The <code>community\.azure</code> collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://github\.com/ansible\-community/community\-topics/issues/263](https\://github\.com/ansible\-community/community\-topics/issues/263)\)\.
+* The <code>hpe\.nimble</code> collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://github\.com/ansible\-community/community\-topics/issues/254](https\://github\.com/ansible\-community/community\-topics/issues/254)\)\.
+* The <code>netapp\.azure</code> collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://github\.com/ansible\-community/community\-topics/issues/234](https\://github\.com/ansible\-community/community\-topics/issues/234)\)\.
+* The <code>netapp\.elementsw</code> collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://github\.com/ansible\-community/community\-topics/issues/235](https\://github\.com/ansible\-community/community\-topics/issues/235)\)\.
+* The <code>netapp\.um\_info</code> collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
+  See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://github\.com/ansible\-community/community\-topics/issues/244](https\://github\.com/ansible\-community/community\-topics/issues/244)\)\.
+* The collection <code>community\.sap</code> was renamed to <code>community\.sap\_libs</code>\.
+  For now both collections are included in Ansible\.
+  The collection will be completely removed from Ansible 10\.
+  Please update your FQCNs from <code>community\.sap</code> to <code>community\.sap\_libs</code>\.
+* The collection <code>ibm\.spectrum\_virtualize</code> was renamed to <code>ibm\.storage\_virtualize</code>\.
+  For now both collections are included in Ansible\.
+  The content in <code>ibm\.spectrum\_virtualize</code> will be replaced by deprecated redirects in Ansible 10\.0\.0\.
+  The collection will be completely removed from Ansible eventually\.
+  Please update your FQCNs from <code>ibm\.spectrum\_virtualize</code> to <code>ibm\.storage\_virtualize</code>\.
+* The collection <code>t\_systems\_mms\.icinga\_director</code> was renamed to <code>telekom\_mms\.icinga\_director</code>\.
+  For now both collections are included in Ansible\.
+  The content in <code>t\_systems\_mms\.icinga\_director</code> has been replaced by deprecated redirects in Ansible 9\.0\.0\.
+  The collection will be completely removed from Ansible 11\.
+  Please update your FQCNs from <code>t\_systems\_mms\.icinga\_director</code> to <code>telekom\_mms\.icinga\_director</code>\.
 
 <a id="ansible-core-32"></a>
 #### Ansible\-core
@@ -8129,12 +8153,20 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 <a id="removed-features-previously-deprecated-1"></a>
 ### Removed Features \(previously deprecated\)
 
-* The deprecated servicenow\.servicenow collection has been removed from Ansible 7\, but accidentally re\-added to Ansible 8\. It has been removed again from Ansible 9 \([https\://github\.com/ansible\-community/community\-topics/issues/246](https\://github\.com/ansible\-community/community\-topics/issues/246)\)\.
-* The ngine\_io\.vultr collection has been removed from Ansible 9\, because it is officially unmaintained and has been archived\. The successor collection <code>vultr\.cloud</code> \(using the recent v2 Vultr API\) covers the same functionality but might not have compatible syntax \([https\://github\.com/ansible\-community/community\-topics/issues/257](https\://github\.com/ansible\-community/community\-topics/issues/257)\)\.
-* <code>cisco\.nso</code> was considered unmaintained and removed from Ansible 9 as per the [removal from Ansible process](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#unmaintained\-collections)\. Users can still install this collection with <code>ansible\-galaxy collection install cisco\.nso</code>\.
-* <code>community\.fortios</code> was considered unmaintained and removed from Ansible 9 as per the [removal from Ansible process](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#unmaintained\-collections)\. Users can still install this collection with <code>ansible\-galaxy collection install community\.fortios</code>\.
-* <code>community\.google</code> was considered unmaintained and removed from Ansible 9 as per the [removal from Ansible process](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#unmaintained\-collections)\. Users can still install this collection with <code>ansible\-galaxy collection install community\.google</code>\.
-* <code>community\.skydive</code> was considered unmaintained and removed from Ansible 9 as per the [removal from Ansible process](https\://github\.com/ansible\-collections/overview/blob/main/removal\_from\_ansible\.rst\#unmaintained\-collections)\. Users can still install this collection with <code>ansible\-galaxy collection install community\.skydive</code>\.
+* The <code>cisco\.nso</code> collection was considered unmaintained and has been removed from Ansible 9 \([https\://github\.com/ansible\-community/community\-topics/issues/155](https\://github\.com/ansible\-community/community\-topics/issues/155)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install cisco\.nso</code>\.
+* The <code>community\.fortios</code> collection was considered unmaintained and has been removed from Ansible 9 \([https\://github\.com/ansible\-community/community\-topics/issues/162](https\://github\.com/ansible\-community/community\-topics/issues/162)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install community\.fortios</code>\.
+* The <code>community\.google</code> collection was considered unmaintained and has been removed from Ansible 9 \([https\://github\.com/ansible\-community/community\-topics/issues/160](https\://github\.com/ansible\-community/community\-topics/issues/160)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install community\.google</code>\.
+* The <code>community\.skydive</code> collection was considered unmaintained and has been removed from Ansible 9 \([https\://github\.com/ansible\-community/community\-topics/issues/171](https\://github\.com/ansible\-community/community\-topics/issues/171)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install community\.skydive</code>\.
+* The <code>ngine\_io\.vultr</code> collection was considered unmaintained and has been removed from Ansible 9 \([https\://github\.com/ansible\-community/community\-topics/issues/257](https\://github\.com/ansible\-community/community\-topics/issues/257)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install ngine\_io\.vultr</code>\.
+* The servicenow\.servicenow collection has been removed from Ansible 9\.
+  The deprecated servicenow\.servicenow collection has been removed from Ansible 7\, but accidentally re\-added to Ansible 8\.
+  See [the removal discussion](https\://github\.com/ansible\-community/community\-topics/issues/246) for details\.
+  Users can still install this collection with <code>ansible\-galaxy collection install servicenow\.servicenow</code>\.
 
 <a id="ansible-core-33"></a>
 #### Ansible\-core

--- a/9/CHANGELOG-v9.rst
+++ b/9/CHANGELOG-v9.rst
@@ -1158,8 +1158,12 @@ purestorage.flasharray
 Deprecated Features
 -------------------
 
-- The ``frr.frr`` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/6243).
-- The ``openvswitch.openvswitch`` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/6245).
+- The ``frr.frr`` collection has been deprecated.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/6243 <https://forum.ansible.com/t/6243>`__).
+- The ``openvswitch.openvswitch`` collection has been deprecated.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/6245 <https://forum.ansible.com/t/6245>`__).
 
 Bugfixes
 --------
@@ -3790,9 +3794,13 @@ purestorage.fusion
 Deprecated Features
 -------------------
 
-- The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/2854).
-- The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/2811).
-- The ``purestorage.fusion`` collection is officially unmaintained and has been archived. Therefore, it will be removed from Ansible 10 (https://forum.ansible.com/t/3712).
+- The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2854 <https://forum.ansible.com/t/2854>`__).
+- The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2811 <https://forum.ansible.com/t/2811>`__).
+- The ``purestorage.fusion`` collection has been deprecated.
+  It will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/3712 <https://forum.ansible.com/t/3712>`__).
 
 community.crypto
 ~~~~~~~~~~~~~~~~
@@ -7442,14 +7450,30 @@ hetzner.hcloud
 Deprecated Features
 -------------------
 
-- The ``community.azure`` collection is officially unmaintained and has been archived. Therefore, it will be removed from Ansible 10. There is already a successor collection ``azure.azcollection`` in the community package which should cover the same functionality (https://github.com/ansible-community/community-topics/issues/263).
-- The ``hpe.nimble`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://github.com/ansible-community/community-topics/issues/254).
-- The collection ``community.sap`` has been renamed to ``community.sap_libs``. For now both collections are included in Ansible. The content in ``community.sap`` has deprecated redirects to the new collection in Ansible 9.0.0, and the collection will be removed from Ansible 10 completely. Please update your FQCNs for ``community.sap``.
-- The collection ``ibm.spectrum_virtualize`` has been renamed to ``ibm.storage_virtualize``. For now, both collections are included in Ansible. The content in ``ibm.spectrum_virtualize`` will be replaced with deprecated redirects to the new collection in Ansible 10.0.0, and these redirects will eventually be removed from Ansible. Please update your FQCNs for ``ibm.spectrum_virtualize``.
-- The collection ``t_systems_mms.icinga_director`` has been renamed to ``telekom_mms.icinga_director``. For now both collections are included in Ansible. The content in ``t_systems_mms.icinga_director`` has been replaced with deprecated redirects to the new collection in Ansible 9.0.0, and these redirects will be removed from Ansible 11. Please update your FQCNs for ``t_systems_mms.icinga_director``.
-- The netapp.azure collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://github.com/ansible-community/community-topics/issues/234).
-- The netapp.elementsw collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://github.com/ansible-community/community-topics/issues/235).
-- The netapp.um_info collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://github.com/ansible-community/community-topics/issues/244).
+- The ``community.azure`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/263 <https://github.com/ansible-community/community-topics/issues/263>`__).
+- The ``hpe.nimble`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/254 <https://github.com/ansible-community/community-topics/issues/254>`__).
+- The ``netapp.azure`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/234 <https://github.com/ansible-community/community-topics/issues/234>`__).
+- The ``netapp.elementsw`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/235 <https://github.com/ansible-community/community-topics/issues/235>`__).
+- The ``netapp.um_info`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/244 <https://github.com/ansible-community/community-topics/issues/244>`__).
+- The collection ``community.sap`` was renamed to ``community.sap_libs``.
+  For now both collections are included in Ansible.
+  The collection will be completely removed from Ansible 10.
+  Please update your FQCNs from ``community.sap`` to ``community.sap_libs``.
+- The collection ``ibm.spectrum_virtualize`` was renamed to ``ibm.storage_virtualize``.
+  For now both collections are included in Ansible.
+  The content in ``ibm.spectrum_virtualize`` will be replaced by deprecated redirects in Ansible 10.0.0.
+  The collection will be completely removed from Ansible eventually.
+  Please update your FQCNs from ``ibm.spectrum_virtualize`` to ``ibm.storage_virtualize``.
+- The collection ``t_systems_mms.icinga_director`` was renamed to ``telekom_mms.icinga_director``.
+  For now both collections are included in Ansible.
+  The content in ``t_systems_mms.icinga_director`` has been replaced by deprecated redirects in Ansible 9.0.0.
+  The collection will be completely removed from Ansible 11.
+  Please update your FQCNs from ``t_systems_mms.icinga_director`` to ``telekom_mms.icinga_director``.
 
 Ansible-core
 ~~~~~~~~~~~~
@@ -7621,12 +7645,20 @@ t_systems_mms.icinga_director
 Removed Features (previously deprecated)
 ----------------------------------------
 
-- The deprecated servicenow.servicenow collection has been removed from Ansible 7, but accidentally re-added to Ansible 8. It has been removed again from Ansible 9 (https://github.com/ansible-community/community-topics/issues/246).
-- The ngine_io.vultr collection has been removed from Ansible 9, because it is officially unmaintained and has been archived. The successor collection ``vultr.cloud`` (using the recent v2 Vultr API) covers the same functionality but might not have compatible syntax (https://github.com/ansible-community/community-topics/issues/257).
-- ``cisco.nso`` was considered unmaintained and removed from Ansible 9 as per the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_. Users can still install this collection with ``ansible-galaxy collection install cisco.nso``.
-- ``community.fortios`` was considered unmaintained and removed from Ansible 9 as per the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_. Users can still install this collection with ``ansible-galaxy collection install community.fortios``.
-- ``community.google`` was considered unmaintained and removed from Ansible 9 as per the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_. Users can still install this collection with ``ansible-galaxy collection install community.google``.
-- ``community.skydive`` was considered unmaintained and removed from Ansible 9 as per the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_. Users can still install this collection with ``ansible-galaxy collection install community.skydive``.
+- The ``cisco.nso`` collection was considered unmaintained and has been removed from Ansible 9 (`https://github.com/ansible-community/community-topics/issues/155 <https://github.com/ansible-community/community-topics/issues/155>`__).
+  Users can still install this collection with ``ansible-galaxy collection install cisco.nso``.
+- The ``community.fortios`` collection was considered unmaintained and has been removed from Ansible 9 (`https://github.com/ansible-community/community-topics/issues/162 <https://github.com/ansible-community/community-topics/issues/162>`__).
+  Users can still install this collection with ``ansible-galaxy collection install community.fortios``.
+- The ``community.google`` collection was considered unmaintained and has been removed from Ansible 9 (`https://github.com/ansible-community/community-topics/issues/160 <https://github.com/ansible-community/community-topics/issues/160>`__).
+  Users can still install this collection with ``ansible-galaxy collection install community.google``.
+- The ``community.skydive`` collection was considered unmaintained and has been removed from Ansible 9 (`https://github.com/ansible-community/community-topics/issues/171 <https://github.com/ansible-community/community-topics/issues/171>`__).
+  Users can still install this collection with ``ansible-galaxy collection install community.skydive``.
+- The ``ngine_io.vultr`` collection was considered unmaintained and has been removed from Ansible 9 (`https://github.com/ansible-community/community-topics/issues/257 <https://github.com/ansible-community/community-topics/issues/257>`__).
+  Users can still install this collection with ``ansible-galaxy collection install ngine_io.vultr``.
+- The servicenow.servicenow collection has been removed from Ansible 9.
+  The deprecated servicenow.servicenow collection has been removed from Ansible 7, but accidentally re-added to Ansible 8.
+  See `the removal discussion <https://github.com/ansible-community/community-topics/issues/246>`__ for details.
+  Users can still install this collection with ``ansible-galaxy collection install servicenow.servicenow``.
 
 Ansible-core
 ~~~~~~~~~~~~

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -6,36 +6,6 @@ releases:
     release_date: '2023-11-21'
   9.0.0a1:
     changes:
-      deprecated_features:
-      - The ``community.azure`` collection is officially unmaintained and has been
-        archived. Therefore, it will be removed from Ansible 10. There is already
-        a successor collection ``azure.azcollection`` in the community package which
-        should cover the same functionality (https://github.com/ansible-community/community-topics/issues/263).
-      - The ``hpe.nimble`` collection is considered unmaintained and will be removed
-        from Ansible 10 if no one starts maintaining it again before Ansible 10. See
-        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
-        (https://github.com/ansible-community/community-topics/issues/254).
-      - The collection ``community.sap`` has been renamed to ``community.sap_libs``.
-        For now both collections are included in Ansible. The content in ``community.sap``
-        has deprecated redirects to the new collection in Ansible 9.0.0, and the collection
-        will be removed from Ansible 10 completely. Please update your FQCNs for ``community.sap``.
-      - The collection ``t_systems_mms.icinga_director`` has been renamed to ``telekom_mms.icinga_director``.
-        For now both collections are included in Ansible. The content in ``t_systems_mms.icinga_director``
-        has been replaced with deprecated redirects to the new collection in Ansible
-        9.0.0, and these redirects will be removed from Ansible 11. Please update
-        your FQCNs for ``t_systems_mms.icinga_director``.
-      - The netapp.azure collection is considered unmaintained and will be removed
-        from Ansible 10 if no one starts maintaining it again before Ansible 10. See
-        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
-        (https://github.com/ansible-community/community-topics/issues/234).
-      - The netapp.elementsw collection is considered unmaintained and will be removed
-        from Ansible 10 if no one starts maintaining it again before Ansible 10. See
-        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
-        (https://github.com/ansible-community/community-topics/issues/235).
-      - The netapp.um_info collection is considered unmaintained and will be removed
-        from Ansible 10 if no one starts maintaining it again before Ansible 10. See
-        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
-        (https://github.com/ansible-community/community-topics/issues/244).
       minor_changes:
       - Move setuptools configuration into the declarative ``setup.cfg`` format. ``ansible``
         sdists still contain a stub ``setup.py`` file, but we recommend that users
@@ -45,30 +15,6 @@ releases:
 
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
-      removed_features:
-      - The deprecated servicenow.servicenow collection has been removed from Ansible
-        7, but accidentally re-added to Ansible 8. It has been removed again from
-        Ansible 9 (https://github.com/ansible-community/community-topics/issues/246).
-      - The ngine_io.vultr collection has been removed from Ansible 9, because it
-        is officially unmaintained and has been archived. The successor collection
-        ``vultr.cloud`` (using the recent v2 Vultr API) covers the same functionality
-        but might not have compatible syntax (https://github.com/ansible-community/community-topics/issues/257).
-      - '``cisco.nso`` was considered unmaintained and removed from Ansible 9 as per
-        the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_.
-        Users can still install this collection with ``ansible-galaxy collection install
-        cisco.nso``.'
-      - '``community.fortios`` was considered unmaintained and removed from Ansible
-        9 as per the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_.
-        Users can still install this collection with ``ansible-galaxy collection install
-        community.fortios``.'
-      - '``community.google`` was considered unmaintained and removed from Ansible
-        9 as per the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_.
-        Users can still install this collection with ``ansible-galaxy collection install
-        community.google``.'
-      - '``community.skydive`` was considered unmaintained and removed from Ansible
-        9 as per the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_.
-        Users can still install this collection with ``ansible-galaxy collection install
-        community.skydive``.'
     release_date: '2023-09-28'
   9.0.0a2:
     changes:
@@ -86,12 +32,6 @@ releases:
     release_date: '2023-10-17'
   9.0.0b1:
     changes:
-      deprecated_features:
-      - The collection ``ibm.spectrum_virtualize`` has been renamed to ``ibm.storage_virtualize``.
-        For now, both collections are included in Ansible. The content in ``ibm.spectrum_virtualize``
-        will be replaced with deprecated redirects to the new collection in Ansible
-        10.0.0, and these redirects will eventually be removed from Ansible. Please
-        update your FQCNs for ``ibm.spectrum_virtualize``.
       release_summary: 'Release Date: 2023-11-07
 
 
@@ -128,17 +68,6 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2024-09-10'
-  9.11.0:
-    changes:
-      deprecated_features:
-      - The ``ngine_io.exoscale`` collection has been deprecated by the maintainers. Since they've
-        also announced that the collection does not work anymore with the Cloudstack API after May 1, 2024,
-        it will be removed from Ansible 11
-        (https://forum.ansible.com/t/2572).
-      - The ``sensu.sensu_go`` collection will be removed from Ansible 12 due
-        to unresolved Ansible inclusion requirements violations
-        (https://forum.ansible.com/t/8380).
-        See `the removal process for details on how this works and can be cancelled <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__.
   9.2.0:
     changes:
       release_summary: 'Release Date: 2024-01-30
@@ -148,17 +77,6 @@ releases:
     release_date: '2024-01-30'
   9.3.0:
     changes:
-      deprecated_features:
-      - The ``inspur.sm`` collection is considered unmaintained and will be removed
-        from Ansible 11 if no one starts maintaining it again before Ansible 11. See
-        `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
-        (https://forum.ansible.com/t/2854).
-      - The ``netapp.storagegrid`` collection is considered unmaintained and will
-        be removed from Ansible 11 if no one starts maintaining it again before Ansible
-        11. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__
-        (https://forum.ansible.com/t/2811).
-      - The ``purestorage.fusion`` collection is officially unmaintained and has been
-        archived. Therefore, it will be removed from Ansible 10 (https://forum.ansible.com/t/3712).
       release_summary: 'Release Date: 2024-02-27
 
 
@@ -210,17 +128,6 @@ releases:
     release_date: '2024-06-18'
   9.8.0:
     changes:
-      deprecated_features:
-      - The ``frr.frr`` collection has been deprecated by the maintainers. Since they've
-        also announced to not support ansible-core 2.18, it will be removed from Ansible
-        11 if no one starts maintaining it again before Ansible 11. See `the removal
-        process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
-        (https://forum.ansible.com/t/6243).
-      - The ``openvswitch.openvswitch`` collection has been deprecated by the maintainers.
-        Since they've also announced to not support ansible-core 2.18, it will be
-        removed from Ansible 11 if no one starts maintaining it again before Ansible
-        11. See `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
-        (https://forum.ansible.com/t/6245).
       release_summary: 'Release Date: 2024-07-16
 
 

--- a/9/porting_guide_9.rst
+++ b/9/porting_guide_9.rst
@@ -158,8 +158,12 @@ fortinet.fortios
 Deprecated Features
 -------------------
 
-- The ``frr.frr`` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/6243).
-- The ``openvswitch.openvswitch`` collection has been deprecated by the maintainers. Since they've also announced to not support ansible-core 2.18, it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/6245).
+- The ``frr.frr`` collection has been deprecated.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/6243 <https://forum.ansible.com/t/6243>`__).
+- The ``openvswitch.openvswitch`` collection has been deprecated.
+  It will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/6245 <https://forum.ansible.com/t/6245>`__).
 
 Porting Guide for v9.7.0
 ========================
@@ -320,9 +324,13 @@ fortinet.fortios
 Deprecated Features
 -------------------
 
-- The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/2854).
-- The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://forum.ansible.com/t/2811).
-- The ``purestorage.fusion`` collection is officially unmaintained and has been archived. Therefore, it will be removed from Ansible 10 (https://forum.ansible.com/t/3712).
+- The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2854 <https://forum.ansible.com/t/2854>`__).
+- The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2811 <https://forum.ansible.com/t/2811>`__).
+- The ``purestorage.fusion`` collection has been deprecated.
+  It will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/3712 <https://forum.ansible.com/t/3712>`__).
 
 community.crypto
 ~~~~~~~~~~~~~~~~
@@ -677,12 +685,20 @@ Removed Collections
 Removed Features
 ----------------
 
-- The deprecated servicenow.servicenow collection has been removed from Ansible 7, but accidentally re-added to Ansible 8. It has been removed again from Ansible 9 (https://github.com/ansible-community/community-topics/issues/246).
-- The ngine_io.vultr collection has been removed from Ansible 9, because it is officially unmaintained and has been archived. The successor collection ``vultr.cloud`` (using the recent v2 Vultr API) covers the same functionality but might not have compatible syntax (https://github.com/ansible-community/community-topics/issues/257).
-- ``cisco.nso`` was considered unmaintained and removed from Ansible 9 as per the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_. Users can still install this collection with ``ansible-galaxy collection install cisco.nso``.
-- ``community.fortios`` was considered unmaintained and removed from Ansible 9 as per the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_. Users can still install this collection with ``ansible-galaxy collection install community.fortios``.
-- ``community.google`` was considered unmaintained and removed from Ansible 9 as per the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_. Users can still install this collection with ``ansible-galaxy collection install community.google``.
-- ``community.skydive`` was considered unmaintained and removed from Ansible 9 as per the `removal from Ansible process <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#unmaintained-collections>`_. Users can still install this collection with ``ansible-galaxy collection install community.skydive``.
+- The ``cisco.nso`` collection was considered unmaintained and has been removed from Ansible 9 (`https://github.com/ansible-community/community-topics/issues/155 <https://github.com/ansible-community/community-topics/issues/155>`__).
+  Users can still install this collection with ``ansible-galaxy collection install cisco.nso``.
+- The ``community.fortios`` collection was considered unmaintained and has been removed from Ansible 9 (`https://github.com/ansible-community/community-topics/issues/162 <https://github.com/ansible-community/community-topics/issues/162>`__).
+  Users can still install this collection with ``ansible-galaxy collection install community.fortios``.
+- The ``community.google`` collection was considered unmaintained and has been removed from Ansible 9 (`https://github.com/ansible-community/community-topics/issues/160 <https://github.com/ansible-community/community-topics/issues/160>`__).
+  Users can still install this collection with ``ansible-galaxy collection install community.google``.
+- The ``community.skydive`` collection was considered unmaintained and has been removed from Ansible 9 (`https://github.com/ansible-community/community-topics/issues/171 <https://github.com/ansible-community/community-topics/issues/171>`__).
+  Users can still install this collection with ``ansible-galaxy collection install community.skydive``.
+- The ``ngine_io.vultr`` collection was considered unmaintained and has been removed from Ansible 9 (`https://github.com/ansible-community/community-topics/issues/257 <https://github.com/ansible-community/community-topics/issues/257>`__).
+  Users can still install this collection with ``ansible-galaxy collection install ngine_io.vultr``.
+- The servicenow.servicenow collection has been removed from Ansible 9.
+  The deprecated servicenow.servicenow collection has been removed from Ansible 7, but accidentally re-added to Ansible 8.
+  See `the removal discussion <https://github.com/ansible-community/community-topics/issues/246>`__ for details.
+  Users can still install this collection with ``ansible-galaxy collection install servicenow.servicenow``.
 
 Ansible-core
 ~~~~~~~~~~~~
@@ -797,14 +813,30 @@ hetzner.hcloud
 Deprecated Features
 -------------------
 
-- The ``community.azure`` collection is officially unmaintained and has been archived. Therefore, it will be removed from Ansible 10. There is already a successor collection ``azure.azcollection`` in the community package which should cover the same functionality (https://github.com/ansible-community/community-topics/issues/263).
-- The ``hpe.nimble`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://github.com/ansible-community/community-topics/issues/254).
-- The collection ``community.sap`` has been renamed to ``community.sap_libs``. For now both collections are included in Ansible. The content in ``community.sap`` has deprecated redirects to the new collection in Ansible 9.0.0, and the collection will be removed from Ansible 10 completely. Please update your FQCNs for ``community.sap``.
-- The collection ``ibm.spectrum_virtualize`` has been renamed to ``ibm.storage_virtualize``. For now, both collections are included in Ansible. The content in ``ibm.spectrum_virtualize`` will be replaced with deprecated redirects to the new collection in Ansible 10.0.0, and these redirects will eventually be removed from Ansible. Please update your FQCNs for ``ibm.spectrum_virtualize``.
-- The collection ``t_systems_mms.icinga_director`` has been renamed to ``telekom_mms.icinga_director``. For now both collections are included in Ansible. The content in ``t_systems_mms.icinga_director`` has been replaced with deprecated redirects to the new collection in Ansible 9.0.0, and these redirects will be removed from Ansible 11. Please update your FQCNs for ``t_systems_mms.icinga_director``.
-- The netapp.azure collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://github.com/ansible-community/community-topics/issues/234).
-- The netapp.elementsw collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://github.com/ansible-community/community-topics/issues/235).
-- The netapp.um_info collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10. See `the removal process for details on how this works <https://github.com/ansible-collections/overview/blob/main/removal_from_ansible.rst#cancelling-removal-of-an-unmaintained-collection>`__ (https://github.com/ansible-community/community-topics/issues/244).
+- The ``community.azure`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/263 <https://github.com/ansible-community/community-topics/issues/263>`__).
+- The ``hpe.nimble`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/254 <https://github.com/ansible-community/community-topics/issues/254>`__).
+- The ``netapp.azure`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/234 <https://github.com/ansible-community/community-topics/issues/234>`__).
+- The ``netapp.elementsw`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/235 <https://github.com/ansible-community/community-topics/issues/235>`__).
+- The ``netapp.um_info`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
+  See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/244 <https://github.com/ansible-community/community-topics/issues/244>`__).
+- The collection ``community.sap`` was renamed to ``community.sap_libs``.
+  For now both collections are included in Ansible.
+  The collection will be completely removed from Ansible 10.
+  Please update your FQCNs from ``community.sap`` to ``community.sap_libs``.
+- The collection ``ibm.spectrum_virtualize`` was renamed to ``ibm.storage_virtualize``.
+  For now both collections are included in Ansible.
+  The content in ``ibm.spectrum_virtualize`` will be replaced by deprecated redirects in Ansible 10.0.0.
+  The collection will be completely removed from Ansible eventually.
+  Please update your FQCNs from ``ibm.spectrum_virtualize`` to ``ibm.storage_virtualize``.
+- The collection ``t_systems_mms.icinga_director`` was renamed to ``telekom_mms.icinga_director``.
+  For now both collections are included in Ansible.
+  The content in ``t_systems_mms.icinga_director`` has been replaced by deprecated redirects in Ansible 9.0.0.
+  The collection will be completely removed from Ansible 11.
+  Please update your FQCNs from ``t_systems_mms.icinga_director`` to ``telekom_mms.icinga_director``.
 
 Ansible-core
 ~~~~~~~~~~~~


### PR DESCRIPTION
Use https://github.com/ansible-community/antsibull/pull/623 to automatically generate collection deprecation changelog entries from metadata.