### PR TITLE
t_systems_mms.icinga_director should have been remove from Ansible 11

### DIFF
--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -134,3 +134,11 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2024-09-10'
+  10.5.0:
+    changes:
+      deprecated_features:
+      - The collection ``t_systems_mms.icinga_director`` has been renamed to ``telekom_mms.icinga_director``.
+        For now both collections are included in Ansible. The content in ``t_systems_mms.icinga_director``
+        has been replaced with deprecated redirects to the new collection in Ansible
+        9.0.0, and these redirects will be removed from Ansible 11. Please update
+        your FQCNs for ``t_systems_mms.icinga_director``.

--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -141,4 +141,4 @@ releases:
         For now both collections are included in Ansible. The content in ``t_systems_mms.icinga_director``
         has been replaced with deprecated redirects to the new collection in Ansible
         9.0.0, and these redirects will be removed from Ansible 11. Please update
-        your FQCNs for ``t_systems_mms.icinga_director``.
+        your FQCNs from ``t_systems_mms.icinga_director`` to ``telekom_mms.icinga_director``.

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -309,6 +309,12 @@ collections:
       - rndmh3ro
       - schurzi
     repository: https://github.com/T-Systems-MMS/ansible-collection-icinga-director
+    removal:
+      major_version: 11
+      reason: renamed
+      new_name: telekom_mms.icinga_director
+      announce_version: 10.5.0
+      redirect_replacement_major_version: 9
   telekom_mms.icinga_director:
     changelog-url: https://github.com/telekom-mms/ansible-collection-icinga-director/blob/master/CHANGELOG.md
     maintainers:

--- a/11/ansible.in
+++ b/11/ansible.in
@@ -85,7 +85,6 @@ purestorage.flashblade
 sensu.sensu_go
 splunk.es
 theforeman.foreman
-t_systems_mms.icinga_director
 telekom_mms.icinga_director
 vmware.vmware
 vmware.vmware_rest

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -269,12 +269,6 @@ collections:
     repository: https://github.com/sensu/sensu-go-ansible
   splunk.es:
     repository: https://github.com/ansible-collections/splunk.es
-  t_systems_mms.icinga_director:
-    changelog-url: https://github.com/T-Systems-MMS/ansible-collection-icinga-director/blob/master/CHANGELOG.md
-    maintainers:
-      - rndmh3ro
-      - schurzi
-    repository: https://github.com/T-Systems-MMS/ansible-collection-icinga-director
   telekom_mms.icinga_director:
     changelog-url: https://github.com/telekom-mms/ansible-collection-icinga-director/blob/master/CHANGELOG.md
     maintainers:

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -383,10 +383,11 @@ collections:
       - schurzi
     repository: https://github.com/T-Systems-MMS/ansible-collection-icinga-director
     removal:
-      major_version: 10
+      major_version: 11
       reason: renamed
       new_name: telekom_mms.icinga_director
       announce_version: 9.0.0a1
+      redirect_replacement_major_version: 9
   telekom_mms.icinga_director:
     changelog-url: https://github.com/telekom-mms/ansible-collection-icinga-director/blob/master/CHANGELOG.md
     maintainers:


### PR DESCRIPTION
The collection was renamed, and replaced by deprecated redirects in Ansible 9. Fix metadata, remove old collection from Ansible 11.