### PR TITLE
Remove deprecated collection ngine_io.exoscale

### DIFF
--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -142,3 +142,9 @@ releases:
         has been replaced with deprecated redirects to the new collection in Ansible
         9.0.0, and these redirects will be removed from Ansible 11. Please update
         your FQCNs from ``t_systems_mms.icinga_director`` to ``telekom_mms.icinga_director``.
+      - The ``ngine_io.exoscale`` collection has been deprecated by the maintainers. Since they've
+        also announced that the collection does not work anymore with the Cloudstack API after May 1, 2024,
+        it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+        See `the removal process for details on how this works
+        <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
+        (https://forum.ansible.com/t/2572).

--- a/10/changelog.yaml
+++ b/10/changelog.yaml
@@ -144,7 +144,5 @@ releases:
         your FQCNs from ``t_systems_mms.icinga_director`` to ``telekom_mms.icinga_director``.
       - The ``ngine_io.exoscale`` collection has been deprecated by the maintainers. Since they've
         also announced that the collection does not work anymore with the Cloudstack API after May 1, 2024,
-        it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
-        See `the removal process for details on how this works
-        <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
+        it will be removed from Ansible 11
         (https://forum.ansible.com/t/2572).

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -280,6 +280,11 @@ collections:
     repository: https://github.com/ngine-io/ansible-collection-cloudstack
   ngine_io.exoscale:
     repository: https://github.com/ngine-io/ansible-collection-exoscale
+    removal:
+      major_version: 11
+      reason: deprecated
+      discussion: https://forum.ansible.com/t/2572
+      announce_version: 10.5.0
   openstack.cloud:
     repository: https://opendev.org/openstack/ansible-collections-openstack
   openvswitch.openvswitch:

--- a/11/ansible-11.build
+++ b/11/ansible-11.build
@@ -80,7 +80,6 @@ netapp.ontap: >=22.12.0,<23.0.0
 netapp_eseries.santricity: >=1.4.0,<2.0.0
 netbox.netbox: >=3.20.0,<4.0.0
 ngine_io.cloudstack: >=2.4.0,<3.0.0
-ngine_io.exoscale: >=1.1.0,<2.0.0
 openstack.cloud: >=2.2.0,<3.0.0
 ovirt.ovirt: >=3.2.0,<4.0.0
 purestorage.flasharray: >=1.31.0,<2.0.0

--- a/11/ansible.in
+++ b/11/ansible.in
@@ -77,7 +77,6 @@ netapp_eseries.santricity
 netapp.ontap
 netbox.netbox
 ngine_io.cloudstack
-ngine_io.exoscale
 openstack.cloud
 ovirt.ovirt
 purestorage.flasharray

--- a/11/changelog.yaml
+++ b/11/changelog.yaml
@@ -18,3 +18,8 @@ releases:
       - The ``openvswitch.openvswitch`` collection has been removed because it does
         not support ansible-core 2.18 (https://forum.ansible.com/t/6245).
     release_date: '2024-09-25'
+  11.0.0a2:
+    changes:
+      removed_features:
+      - The ``ngine_io.exoscale`` collection has been removed because it has been deprecated by its maintainers
+        (https://forum.ansible.com/t/2572).

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -251,8 +251,6 @@ collections:
     repository: https://github.com/netbox-community/ansible_modules
   ngine_io.cloudstack:
     repository: https://github.com/ngine-io/ansible-collection-cloudstack
-  ngine_io.exoscale:
-    repository: https://github.com/ngine-io/ansible-collection-exoscale
   openstack.cloud:
     repository: https://opendev.org/openstack/ansible-collections-openstack
   ovirt.ovirt:
@@ -333,6 +331,13 @@ removed_collections:
       reason: considered-unmaintained
       discussion: https://forum.ansible.com/t/2811
       announce_version: 10.0.0a1
+  ngine_io.exoscale:
+    repository: https://github.com/ngine-io/ansible-collection-exoscale
+    removal:
+      version: 11.0.0a2
+      reason: deprecated
+      discussion: https://forum.ansible.com/t/2572
+      announce_version: 10.5.0
   openvswitch.openvswitch:
     repository: https://github.com/ansible-collections/openvswitch.openvswitch
     removal:

--- a/11/galaxy-requirements.yaml
+++ b/11/galaxy-requirements.yaml
@@ -237,9 +237,6 @@ collections:
 - name: ngine_io.cloudstack
   source: https://galaxy.ansible.com
   version: 2.4.1
-- name: ngine_io.exoscale
-  source: https://galaxy.ansible.com
-  version: 1.1.0
 - name: openstack.cloud
   source: https://galaxy.ansible.com
   version: 2.2.0

--- a/11/galaxy-requirements.yaml
+++ b/11/galaxy-requirements.yaml
@@ -237,6 +237,9 @@ collections:
 - name: ngine_io.cloudstack
   source: https://galaxy.ansible.com
   version: 2.4.1
+- name: ngine_io.exoscale
+  source: https://galaxy.ansible.com
+  version: 1.1.0
 - name: openstack.cloud
   source: https://galaxy.ansible.com
   version: 2.2.0

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -133,9 +133,7 @@ releases:
       deprecated_features:
       - The ``ngine_io.exoscale`` collection has been deprecated by the maintainers. Since they've
         also announced that the collection does not work anymore with the Cloudstack API after May 1, 2024,
-        it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
-        See `the removal process for details on how this works
-        <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
+        it will be removed from Ansible 11
         (https://forum.ansible.com/t/2572).
   9.2.0:
     changes:

--- a/9/changelog.yaml
+++ b/9/changelog.yaml
@@ -128,6 +128,15 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/ansible/devel/porting_guides.html>`_'
     release_date: '2024-09-10'
+  9.11.0:
+    changes:
+      deprecated_features:
+      - The ``ngine_io.exoscale`` collection has been deprecated by the maintainers. Since they've
+        also announced that the collection does not work anymore with the Cloudstack API after May 1, 2024,
+        it will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
+        See `the removal process for details on how this works
+        <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#canceling-removal-of-an-unmaintained-collection>`__
+        (https://forum.ansible.com/t/2572).
   9.2.0:
     changes:
       release_summary: 'Release Date: 2024-01-30

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -344,6 +344,11 @@ collections:
     repository: https://github.com/ngine-io/ansible-collection-cloudstack
   ngine_io.exoscale:
     repository: https://github.com/ngine-io/ansible-collection-exoscale
+    removal:
+      major_version: 11
+      reason: deprecated
+      discussion: https://forum.ansible.com/t/2572
+      announce_version: 9.11.0
   openstack.cloud:
     repository: https://opendev.org/openstack/ansible-collections-openstack
   openvswitch.openvswitch:


### PR DESCRIPTION
`ngine_io.exoscale` [has been deprecated](https://github.com/ngine-io/ansible-collection-exoscale/commit/f442921cfc8a514c212ccdda1db20355870ef3c5) and should be removed from the Anisble Community Package.

You can find the discussion on the forum [here](https://forum.ansible.com/t/2572).