### PR TITLE
Add missing removals

### DIFF
--- a/10/CHANGELOG-v10.md
+++ b/10/CHANGELOG-v10.md
@@ -4337,8 +4337,12 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 
 * The <code>community\.azure</code> collection was considered unmaintained and has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/263](https\://github\.com/ansible\-community/community\-topics/issues/263)\)\.
   Users can still install this collection with <code>ansible\-galaxy collection install community\.azure</code>\.
+* The <code>gluster\.gluster</code> collection was considered unmaintained and has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/225](https\://github\.com/ansible\-community/community\-topics/issues/225)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install gluster\.gluster</code>\.
 * The <code>hpe\.nimble</code> collection was considered unmaintained and has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/254](https\://github\.com/ansible\-community/community\-topics/issues/254)\)\.
   Users can still install this collection with <code>ansible\-galaxy collection install hpe\.nimble</code>\.
+* The <code>netapp\.aws</code> collection was considered unmaintained and has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/223](https\://github\.com/ansible\-community/community\-topics/issues/223)\)\.
+  Users can still install this collection with <code>ansible\-galaxy collection install netapp\.aws</code>\.
 * The <code>netapp\.azure</code> collection was considered unmaintained and has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/234](https\://github\.com/ansible\-community/community\-topics/issues/234)\)\.
   Users can still install this collection with <code>ansible\-galaxy collection install netapp\.azure</code>\.
 * The <code>netapp\.elementsw</code> collection was considered unmaintained and has been removed from Ansible 10 \([https\://github\.com/ansible\-community/community\-topics/issues/235](https\://github\.com/ansible\-community/community\-topics/issues/235)\)\.

--- a/10/CHANGELOG-v10.rst
+++ b/10/CHANGELOG-v10.rst
@@ -4030,8 +4030,12 @@ Removed Features (previously deprecated)
 
 - The ``community.azure`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/263 <https://github.com/ansible-community/community-topics/issues/263>`__).
   Users can still install this collection with ``ansible-galaxy collection install community.azure``.
+- The ``gluster.gluster`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/225 <https://github.com/ansible-community/community-topics/issues/225>`__).
+  Users can still install this collection with ``ansible-galaxy collection install gluster.gluster``.
 - The ``hpe.nimble`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/254 <https://github.com/ansible-community/community-topics/issues/254>`__).
   Users can still install this collection with ``ansible-galaxy collection install hpe.nimble``.
+- The ``netapp.aws`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/223 <https://github.com/ansible-community/community-topics/issues/223>`__).
+  Users can still install this collection with ``ansible-galaxy collection install netapp.aws``.
 - The ``netapp.azure`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/234 <https://github.com/ansible-community/community-topics/issues/234>`__).
   Users can still install this collection with ``ansible-galaxy collection install netapp.azure``.
 - The ``netapp.elementsw`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/235 <https://github.com/ansible-community/community-topics/issues/235>`__).

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -381,6 +381,13 @@ removed_collections:
       reason: renamed
       new_name: community.sap_libs
       announce_version: 9.0.0a1
+  gluster.gluster:
+    repository: https://github.com/gluster/gluster-ansible-collection
+    removal:
+      version: 10.0.0a1
+      reason: considered-unmaintained
+      discussion: https://github.com/ansible-community/community-topics/issues/225
+      announce_version: 7.7.0
   hpe.nimble:
     maintainers:
       - ar-india
@@ -392,6 +399,18 @@ removed_collections:
       reason: considered-unmaintained
       discussion: https://github.com/ansible-community/community-topics/issues/254
       announce_version: 9.0.0a1
+  netapp.aws:
+    maintainers:
+      - carchi8py
+      - suhasbshekar
+      - wenjun666
+      - chuyich
+    repository: https://github.com/ansible-collections/netapp.aws
+    removal:
+      version: 10.0.0a1
+      reason: considered-unmaintained
+      discussion: https://github.com/ansible-community/community-topics/issues/223
+      announce_version: 7.7.0
   netapp.azure:
     maintainers:
       - carchi8py

--- a/10/porting_guide_10.rst
+++ b/10/porting_guide_10.rst
@@ -627,8 +627,12 @@ Removed Features
 
 - The ``community.azure`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/263 <https://github.com/ansible-community/community-topics/issues/263>`__).
   Users can still install this collection with ``ansible-galaxy collection install community.azure``.
+- The ``gluster.gluster`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/225 <https://github.com/ansible-community/community-topics/issues/225>`__).
+  Users can still install this collection with ``ansible-galaxy collection install gluster.gluster``.
 - The ``hpe.nimble`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/254 <https://github.com/ansible-community/community-topics/issues/254>`__).
   Users can still install this collection with ``ansible-galaxy collection install hpe.nimble``.
+- The ``netapp.aws`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/223 <https://github.com/ansible-community/community-topics/issues/223>`__).
+  Users can still install this collection with ``ansible-galaxy collection install netapp.aws``.
 - The ``netapp.azure`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/234 <https://github.com/ansible-community/community-topics/issues/234>`__).
   Users can still install this collection with ``ansible-galaxy collection install netapp.azure``.
 - The ``netapp.elementsw`` collection was considered unmaintained and has been removed from Ansible 10 (`https://github.com/ansible-community/community-topics/issues/235 <https://github.com/ansible-community/community-topics/issues/235>`__).

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -195,6 +195,11 @@ collections:
       announce_version: 9.8.0
   gluster.gluster:
     repository: https://github.com/gluster/gluster-ansible-collection
+    removal:
+      major_version: 10
+      reason: considered-unmaintained
+      discussion: https://github.com/ansible-community/community-topics/issues/225
+      announce_version: 7.7.0
   google.cloud:
     repository: https://github.com/ansible-collections/google.cloud
   grafana.grafana:
@@ -280,6 +285,11 @@ collections:
       - wenjun666
       - chuyich
     repository: https://github.com/ansible-collections/netapp.aws
+    removal:
+      major_version: 10
+      reason: considered-unmaintained
+      discussion: https://github.com/ansible-community/community-topics/issues/223
+      announce_version: 7.7.0
   netapp.azure:
     maintainers:
       - carchi8py


### PR DESCRIPTION
10.0.0a1 removed two more collections that weren't announced in the changelog; this fixes that.

Noticed that while working on #465. The new system should prevent this from happening...