### PR TITLE
Restrict ansible.posix to < 1.6.0

### DIFF
--- a/10/ansible-10.constraints
+++ b/10/ansible-10.constraints
@@ -1,0 +1,2 @@
+# ansible.posix 1.6.0 has a breaking change
+ansible.posix: <1.6.0

--- a/9/ansible-9.constraints
+++ b/9/ansible-9.constraints
@@ -1,0 +1,2 @@
+# ansible.posix 1.6.0 has a breaking change
+ansible.posix: <1.6.0


### PR DESCRIPTION
1.6.0 has a breaking change: the skippy plugin has been removed. This is a semantic versioning violation.