### PR TITLE
ansible.posix reverted the breaking change

### DIFF
--- a/10/ansible-10.constraints
+++ b/10/ansible-10.constraints
@@ -1,2 +1,0 @@
-# ansible.posix 1.6.0 has a breaking change
-ansible.posix: <1.6.0

--- a/9/ansible-9.constraints
+++ b/9/ansible-9.constraints
@@ -1,2 +1,0 @@
-# ansible.posix 1.6.0 has a breaking change
-ansible.posix: <1.6.0


### PR DESCRIPTION
It looks like [ansible.posix 1.6.1](https://github.com/ansible-collections/ansible.posix/releases/tag/1.6.1) reverted the breaking change that has been introduced in 1.6.0. We should undo / revert #469.

Ref: https://github.com/ansible-collections/ansible.posix/commit/cd43bd10bbf4401582ef2305dfc74286b9da05a2
Ref: ansible-collections/ansible.posix#574