### PR TITLE
Allow to trigger antsibull-build workflow manually

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -12,6 +12,7 @@ name: antsibull-build
   # Run once per week (Thursday at 04:00 UTC)
   schedule:
     - cron: '0 4 * * 4'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Sometimes it's nice to be able to "just run" the workflow, for example to check whether certain releases from outside the repository broke/fixed a build. Right now this requires to create a PR to trigger CI.