### PR TITLE
Bump Python versions

### DIFF
--- a/.github/workflows/ansible-release.yml
+++ b/.github/workflows/ansible-release.yml
@@ -65,10 +65,10 @@ jobs:
           path: antsibull-build/build/ansible-build-data
           ref: ${{ inputs.existing-branch || '' }}
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install dependencies
         working-directory: antsibull-build

--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -77,10 +77,10 @@ jobs:
         with:
           path: antsibull-build/build/ansible-build-data
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         working-directory: antsibull-build

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -28,7 +28,7 @@ jobs:
       matrix:
         include:
           - session: lint
-            python-versions: "3.12"
+            python-versions: "3.13"
     name: "Run nox ${{ matrix.session }} session"
     steps:
       - name: Check out ansible-build-data


### PR DESCRIPTION
Use Python 3.12 instead of 3.11 for building Ansible (all versions of Ansible currently built should support 3.12).

Use Python 3.13 instead of 3.12 for linting.