### PR TITLE
[WIP] Cancel deprecation of netapp.storagegrid

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -43,8 +43,9 @@ jobs:
       - name: Check out antsibull-core
         uses: actions/checkout@v4
         with:
-          repository: ansible-community/antsibull-core
-          ref: main
+          # TODO: remove
+          repository: felixfontein/antsibull-core
+          ref: cancel-deprecation
           path: antsibull-core
 
       - name: Check out antsibull-changelog

--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -328,6 +328,8 @@ collections:
       reason: considered-unmaintained
       discussion: https://forum.ansible.com/t/2811
       announce_version: 10.0.0a1
+      updates:
+        - cancelled_version: 10.6.0
   netapp_eseries.santricity:
     repository: https://github.com/netapp-eseries/santricity
   netbox.netbox:

--- a/11/ansible-11.build
+++ b/11/ansible-11.build
@@ -78,6 +78,7 @@ microsoft.ad: >=1.7.0,<2.0.0
 netapp.cloudmanager: >=21.22.0,<22.0.0
 netapp.ontap: >=22.12.0,<23.0.0
 netapp_eseries.santricity: >=1.4.0,<2.0.0
+netapp.storagegrid: >=21.13.0,<22.0.0
 netbox.netbox: >=3.20.0,<4.0.0
 ngine_io.cloudstack: >=2.5.0,<3.0.0
 openstack.cloud: >=2.2.0,<3.0.0

--- a/11/ansible.in
+++ b/11/ansible.in
@@ -75,6 +75,7 @@ microsoft.ad
 netapp.cloudmanager
 netapp_eseries.santricity
 netapp.ontap
+netapp.storagegrid
 netbox.netbox
 ngine_io.cloudstack
 openstack.cloud

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -301,6 +301,19 @@ collections:
       - wenjun666
       - chuyich
     repository: https://github.com/ansible-collections/netapp.ontap
+  netapp.storagegrid:
+    maintainers:
+      - carchi8py
+      - jkandati
+      - joshedmonds
+    repository: https://github.com/ansible-collections/netapp.storagegrid
+    removal:
+      major_version: 11
+      reason: considered-unmaintained
+      discussion: https://forum.ansible.com/t/2811
+      updates:
+        - removed_version: 11.0.0a1
+        - readded_version: 11.0.0b1
   netapp_eseries.santricity:
     repository: https://github.com/netapp-eseries/santricity
   netbox.netbox:
@@ -520,17 +533,6 @@ removed_collections:
       reason: considered-unmaintained
       discussion: https://github.com/ansible-community/community-topics/issues/235
       announce_version: 9.0.0a1
-  netapp.storagegrid:
-    maintainers:
-      - carchi8py
-      - jkandati
-      - joshedmonds
-    repository: https://github.com/ansible-collections/netapp.storagegrid
-    removal:
-      version: 11.0.0a1
-      reason: considered-unmaintained
-      discussion: https://forum.ansible.com/t/2811
-      announce_version: 10.0.0a1
   netapp.um_info:
     maintainers:
       - carchi8py

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -380,6 +380,8 @@ collections:
       reason: considered-unmaintained
       discussion: https://forum.ansible.com/t/2811
       announce_version: 9.3.0
+      updates:
+        - cancelled_version: 9.12.0
   netapp.um_info:
     maintainers:
       - carchi8py


### PR DESCRIPTION
Depends on https://forum.ansible.com/t/2811/24

Needs https://github.com/ansible-community/antsibull-core/pull/177 and https://github.com/ansible-community/antsibull-build/pull/640 and https://github.com/ansible-community/antsibull-docs/pull/352.

This will not modify the existing changelogs, and add the following entries:
- 9.12.0:
  ```yaml
  major_changes:
    - The removal of netapp.storagegrid was cancelled. The collection will not be removed from Ansible 11.
  ```
- 10.6.0:
  ```yaml
  major_changes:
    - The removal of netapp.storagegrid was cancelled. The collection will not be removed from Ansible 11.
  ```
- 11.0.0b1:
  ```yaml
  major_changes:
    - The previously removed collection netapp.storagegrid was re-added to Ansible 11.
  ```