### PR TITLE
Re-add netapp.storagegrid to Ansible 11

### DIFF
--- a/11/ansible-11.build
+++ b/11/ansible-11.build
@@ -77,6 +77,7 @@ lowlydba.sqlserver: >=2.3.0,<3.0.0
 microsoft.ad: >=1.7.0,<2.0.0
 netapp.cloudmanager: >=21.24.0,<22.0.0
 netapp.ontap: >=22.12.0,<23.0.0
+netapp.storagegrid: >=21.13.0,<22.0.0
 netapp_eseries.santricity: >=1.4.0,<2.0.0
 netbox.netbox: >=3.20.0,<4.0.0
 ngine_io.cloudstack: >=2.5.0,<3.0.0

--- a/11/ansible.in
+++ b/11/ansible.in
@@ -75,6 +75,7 @@ microsoft.ad
 netapp.cloudmanager
 netapp_eseries.santricity
 netapp.ontap
+netapp.storagegrid
 netbox.netbox
 ngine_io.cloudstack
 openstack.cloud

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -301,6 +301,12 @@ collections:
       - wenjun666
       - chuyich
     repository: https://github.com/ansible-collections/netapp.ontap
+  netapp.storagegrid:
+    maintainers:
+      - carchi8py
+      - jkandati
+      - joshedmonds
+    repository: https://github.com/ansible-collections/netapp.storagegrid
   netapp_eseries.santricity:
     repository: https://github.com/netapp-eseries/santricity
   netbox.netbox:
@@ -520,17 +526,6 @@ removed_collections:
       reason: considered-unmaintained
       discussion: https://github.com/ansible-community/community-topics/issues/235
       announce_version: 9.0.0a1
-  netapp.storagegrid:
-    maintainers:
-      - carchi8py
-      - jkandati
-      - joshedmonds
-    repository: https://github.com/ansible-collections/netapp.storagegrid
-    removal:
-      version: 11.0.0a1
-      reason: considered-unmaintained
-      discussion: https://forum.ansible.com/t/2811
-      announce_version: 10.0.0a1
   netapp.um_info:
     maintainers:
       - carchi8py


### PR DESCRIPTION
We discussed the vote and [action on it on Monday](https://forum.ansible.com/t/2811/28) at today's community meeting. My interpretation of the process was definitely wrong, in case of missed quorum we should have re-added the collection. (We need to improve the formulation (right now it's quite convoluted) and also to clarify some other aspects.) We decided to do another beta release, 11.0.0b1, today with netapp.storagegrid re-added.

This is a resurrection of #489.