### PR TITLE
Remove ibm.spectrum_virtualize from Ansible 12

### DIFF
--- a/10/collection-meta.yaml
+++ b/10/collection-meta.yaml
@@ -242,8 +242,9 @@ collections:
       - Shilpi-J
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
     removal:
-      major_version: TBD
+      major_version: 12
       reason: renamed
+      announce_version: 10.7.0
       new_name: ibm.storage_virtualize
   ibm.storage_virtualize:
     maintainers:

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -235,8 +235,9 @@ collections:
       - Shilpi-J
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
     removal:
-      major_version: TBD
+      major_version: 12
       reason: renamed
+      announce_version: 11.1.0
       new_name: ibm.storage_virtualize
   ibm.storage_virtualize:
     maintainers:

--- a/12/ansible.in
+++ b/12/ansible.in
@@ -58,7 +58,6 @@ fortinet.fortios
 grafana.grafana
 hetzner.hcloud
 ibm.qradar
-ibm.spectrum_virtualize
 ibm.storage_virtualize
 ieisystem.inmanage
 infinidat.infinibox

--- a/12/collection-meta.yaml
+++ b/12/collection-meta.yaml
@@ -213,14 +213,6 @@ collections:
     repository: https://github.com/ansible-collections/hetzner.hcloud
   ibm.qradar:
     repository: https://github.com/ansible-collections/ibm.qradar
-  ibm.spectrum_virtualize:
-    maintainers:
-      - Shilpi-J
-    repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
-    removal:
-      major_version: TBD
-      reason: renamed
-      new_name: ibm.storage_virtualize
   ibm.storage_virtualize:
     maintainers:
       - sumitguptaibm
@@ -464,6 +456,14 @@ removed_collections:
       reason: considered-unmaintained
       discussion: https://github.com/ansible-community/community-topics/issues/254
       announce_version: 9.0.0a1
+  ibm.spectrum_virtualize:
+    maintainers:
+      - Shilpi-J
+    repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
+    removal:
+      version: 12.0.0a1
+      reason: renamed
+      new_name: ibm.storage_virtualize
   inspur.sm:
     maintainers:
       - ISIB-Group

--- a/9/CHANGELOG-v9.md
+++ b/9/CHANGELOG-v9.md
@@ -8929,7 +8929,7 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 * The collection <code>ibm\.spectrum\_virtualize</code> was renamed to <code>ibm\.storage\_virtualize</code>\.
   For now both collections are included in Ansible\.
   The content in <code>ibm\.spectrum\_virtualize</code> will be replaced by deprecated redirects in Ansible 10\.0\.0\.
-  The collection will be completely removed from Ansible eventually\.
+  The collection will be completely removed from Ansible 12\.
   Please update your FQCNs from <code>ibm\.spectrum\_virtualize</code> to <code>ibm\.storage\_virtualize</code>\.
 * The collection <code>t\_systems\_mms\.icinga\_director</code> was renamed to <code>telekom\_mms\.icinga\_director</code>\.
   For now both collections are included in Ansible\.

--- a/9/CHANGELOG-v9.rst
+++ b/9/CHANGELOG-v9.rst
@@ -8373,7 +8373,7 @@ Deprecated Features
 - The collection ``ibm.spectrum_virtualize`` was renamed to ``ibm.storage_virtualize``.
   For now both collections are included in Ansible.
   The content in ``ibm.spectrum_virtualize`` will be replaced by deprecated redirects in Ansible 10.0.0.
-  The collection will be completely removed from Ansible eventually.
+  The collection will be completely removed from Ansible 12.
   Please update your FQCNs from ``ibm.spectrum_virtualize`` to ``ibm.storage_virtualize``.
 - The collection ``t_systems_mms.icinga_director`` was renamed to ``telekom_mms.icinga_director``.
   For now both collections are included in Ansible.

--- a/9/collection-meta.yaml
+++ b/9/collection-meta.yaml
@@ -266,7 +266,7 @@ collections:
       - Shilpi-J
     repository: https://github.com/ansible-collections/ibm.spectrum_virtualize
     removal:
-      major_version: TBD
+      major_version: 12
       reason: renamed
       new_name: ibm.storage_virtualize
       announce_version: 9.0.0b1

--- a/9/porting_guide_9.rst
+++ b/9/porting_guide_9.rst
@@ -882,7 +882,7 @@ Deprecated Features
 - The collection ``ibm.spectrum_virtualize`` was renamed to ``ibm.storage_virtualize``.
   For now both collections are included in Ansible.
   The content in ``ibm.spectrum_virtualize`` will be replaced by deprecated redirects in Ansible 10.0.0.
-  The collection will be completely removed from Ansible eventually.
+  The collection will be completely removed from Ansible 12.
   Please update your FQCNs from ``ibm.spectrum_virtualize`` to ``ibm.storage_virtualize``.
 - The collection ``t_systems_mms.icinga_director`` was renamed to ``telekom_mms.icinga_director``.
   For now both collections are included in Ansible.


### PR DESCRIPTION
The collection hasn't been replaced by redirects *again*, so let's just remove it.

Closes #306.

See also https://forum.ansible.com/t/8119