### PR TITLE
Remove cisco.asa from Ansible 12

### DIFF
--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -41,6 +41,11 @@ collections:
     repository: https://github.com/CiscoDevNet/ansible-aci
   cisco.asa:
     repository: https://github.com/ansible-collections/cisco.asa
+    removal:
+      major_version: 12
+      announce_version: 11.2.0
+      reason: deprecated
+      discussion: https://forum.ansible.com/t/38960
   cisco.dnac:
     maintainers:
       - racampos

--- a/12/ansible.in
+++ b/12/ansible.in
@@ -9,7 +9,6 @@ azure.azcollection
 check_point.mgmt
 chocolatey.chocolatey
 cisco.aci
-cisco.asa
 cisco.dnac
 cisco.intersight
 cisco.ios

--- a/12/collection-meta.yaml
+++ b/12/collection-meta.yaml
@@ -39,8 +39,6 @@ collections:
     collection-directory: "./chocolatey"
   cisco.aci:
     repository: https://github.com/CiscoDevNet/ansible-aci
-  cisco.asa:
-    repository: https://github.com/ansible-collections/cisco.asa
   cisco.dnac:
     maintainers:
       - racampos
@@ -331,6 +329,13 @@ collections:
   wti.remote:
     repository: https://github.com/wtinetworkgear/wti-collection
 removed_collections:
+  cisco.asa:
+    repository: https://github.com/ansible-collections/cisco.asa
+    removal:
+      version: 12.0.0a1
+      reason: deprecated
+      discussion: https://forum.ansible.com/t/38960
+      announce_version: 11.2.0
   cisco.nso:
     repository: https://github.com/CiscoDevNet/ansible-nso
     removal:


### PR DESCRIPTION
Fixes #508

The collection has been deprecated.

See also https://forum.ansible.com/t/38960