### PR TITLE
Remove EOL'ed Ansible versions from CI matrix

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -22,12 +22,6 @@ jobs:
       matrix:
         include:
           # Using ansible_version as X.99.0 since it is unreleased so new deps are generated
-          - name: Ansible 9
-            ansible_version: 9.99.0
-            ansible_major_version: 9
-          - name: Ansible 10
-            ansible_version: 10.99.0
-            ansible_major_version: 10
           - name: Ansible 11
             ansible_version: 11.99.0
             ansible_major_version: 11


### PR DESCRIPTION
CI currently fails due to https://github.com/meraki/dashboard-api-ansible/issues/76. Will create another PR which pins cisco.meraki to 2.18.3 for the remaining active versions.