### PR TITLE
Updated changelogs and porting guides with notes that removed collections can still be installed manually

### DIFF
--- a/10/CHANGELOG-v10.md
+++ b/10/CHANGELOG-v10.md
@@ -851,6 +851,7 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 * The google\.cloud collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements\.
   The collection has [unresolved sanity test failures](https\://github\.com/ansible\-collections/google\.cloud/issues/613)\.
   See [Collections Removal Process for collections not satisfying the collection requirements](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#collections\-not\-satisfying\-the\-collection\-requirements) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/8609](https\://forum\.ansible\.com/t/8609)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install google\.cloud</code>\.
 
 <a id="community-network"></a>
 #### community\.network
@@ -1386,6 +1387,7 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 * The sensu\.sensu\_go collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements\.
   The collection has [unresolved sanity test failures](https\://github\.com/sensu/sensu\-go\-ansible/issues/362)\.
   See [Collections Removal Process for collections not satisfying the collection requirements](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#collections\-not\-satisfying\-the\-collection\-requirements) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/8380](https\://forum\.ansible\.com/t/8380)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install sensu\.sensu\_go</code>\.
 
 <a id="community-general-5"></a>
 #### community\.general
@@ -4379,6 +4381,8 @@ Release Date\: 2024\-06\-04
 * netapp\.um\_info \(previously included version\: 21\.8\.1\)
 * purestorage\.fusion \(previously included version\: 1\.6\.0\)
 
+You can still install a removed collection manually with <code>ansible\-galaxy collection install \<name\-of\-collection\></code>\.
+
 <a id="added-collections-2"></a>
 ### Added Collections
 
@@ -5843,8 +5847,10 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 
 * The <code>inspur\.sm</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
   See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/2854](https\://forum\.ansible\.com/t/2854)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install inspur\.sm</code>\.
 * The <code>netapp\.storagegrid</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
   See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/2811](https\://forum\.ansible\.com/t/2811)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install netapp\.storagegrid</code>\.
 
 <a id="ansible-core-25"></a>
 #### Ansible\-core

--- a/10/CHANGELOG-v10.rst
+++ b/10/CHANGELOG-v10.rst
@@ -706,6 +706,7 @@ Deprecated Features
 - The google.cloud collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/ansible-collections/google.cloud/issues/613>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8609 <https://forum.ansible.com/t/8609>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install google.cloud``.
 
 community.network
 ~~~~~~~~~~~~~~~~~
@@ -1224,6 +1225,7 @@ Deprecated Features
 - The sensu.sensu_go collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/sensu/sensu-go-ansible/issues/362>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8380 <https://forum.ansible.com/t/8380>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install sensu.sensu_go``.
 
 community.general
 ~~~~~~~~~~~~~~~~~
@@ -3904,6 +3906,8 @@ Removed Collections
 - netapp.um_info (previously included version: 21.8.1)
 - purestorage.fusion (previously included version: 1.6.0)
 
+You can still install a removed collection manually with ``ansible-galaxy collection install <name-of-collection>``.
+
 Added Collections
 -----------------
 
@@ -5442,8 +5446,10 @@ Deprecated Features
 
 - The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2854 <https://forum.ansible.com/t/2854>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
 - The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2811 <https://forum.ansible.com/t/2811>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
 
 Ansible-core
 ~~~~~~~~~~~~

--- a/10/porting_guide_10.rst
+++ b/10/porting_guide_10.rst
@@ -199,6 +199,7 @@ Deprecated Features
 - The google.cloud collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/ansible-collections/google.cloud/issues/613>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8609 <https://forum.ansible.com/t/8609>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install google.cloud``.
 
 community.network
 ~~~~~~~~~~~~~~~~~
@@ -250,6 +251,7 @@ Deprecated Features
 - The sensu.sensu_go collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/sensu/sensu-go-ansible/issues/362>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8380 <https://forum.ansible.com/t/8380>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install sensu.sensu_go``.
 
 community.general
 ~~~~~~~~~~~~~~~~~
@@ -772,6 +774,8 @@ Removed Collections
 - netapp.um_info (previously included version: 21.8.1)
 - purestorage.fusion (previously included version: 1.6.0)
 
+You can still install a removed collection manually with ``ansible-galaxy collection install <name-of-collection>``.
+
 Removed Features
 ----------------
 
@@ -881,8 +885,10 @@ Deprecated Features
 
 - The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2854 <https://forum.ansible.com/t/2854>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
 - The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2811 <https://forum.ansible.com/t/2811>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
 
 Ansible-core
 ~~~~~~~~~~~~

--- a/11/CHANGELOG-v11.md
+++ b/11/CHANGELOG-v11.md
@@ -798,6 +798,8 @@ Release Date\: 2024\-11\-19
 * openvswitch\.openvswitch \(previously included version\: 2\.1\.1\)
 * t\_systems\_mms\.icinga\_director \(previously included version\: 2\.0\.1\)
 
+You can still install a removed collection manually with <code>ansible\-galaxy collection install \<name\-of\-collection\></code>\.
+
 <a id="added-collections"></a>
 ### Added Collections
 
@@ -2292,9 +2294,11 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 * The google\.cloud collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements\.
   The collection has [unresolved sanity test failures](https\://github\.com/ansible\-collections/google\.cloud/issues/613)\.
   See [Collections Removal Process for collections not satisfying the collection requirements](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#collections\-not\-satisfying\-the\-collection\-requirements) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/8609](https\://forum\.ansible\.com/t/8609)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install google\.cloud</code>\.
 * The sensu\.sensu\_go collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements\.
   The collection has [unresolved sanity test failures](https\://github\.com/sensu/sensu\-go\-ansible/issues/362)\.
   See [Collections Removal Process for collections not satisfying the collection requirements](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#collections\-not\-satisfying\-the\-collection\-requirements) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/8380](https\://forum\.ansible\.com/t/8380)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install sensu\.sensu\_go</code>\.
 
 <a id="ansible-core-7"></a>
 #### Ansible\-core

--- a/11/CHANGELOG-v11.rst
+++ b/11/CHANGELOG-v11.rst
@@ -541,6 +541,8 @@ Removed Collections
 - openvswitch.openvswitch (previously included version: 2.1.1)
 - t_systems_mms.icinga_director (previously included version: 2.0.1)
 
+You can still install a removed collection manually with ``ansible-galaxy collection install <name-of-collection>``.
+
 Added Collections
 -----------------
 
@@ -2118,9 +2120,11 @@ Deprecated Features
 - The google.cloud collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/ansible-collections/google.cloud/issues/613>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8609 <https://forum.ansible.com/t/8609>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install google.cloud``.
 - The sensu.sensu_go collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/sensu/sensu-go-ansible/issues/362>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8380 <https://forum.ansible.com/t/8380>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install sensu.sensu_go``.
 
 Ansible-core
 ~~~~~~~~~~~~

--- a/11/porting_guide_11.rst
+++ b/11/porting_guide_11.rst
@@ -479,6 +479,8 @@ Removed Collections
 - openvswitch.openvswitch (previously included version: 2.1.1)
 - t_systems_mms.icinga_director (previously included version: 2.0.1)
 
+You can still install a removed collection manually with ``ansible-galaxy collection install <name-of-collection>``.
+
 Removed Features
 ----------------
 
@@ -569,9 +571,11 @@ Deprecated Features
 - The google.cloud collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/ansible-collections/google.cloud/issues/613>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8609 <https://forum.ansible.com/t/8609>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install google.cloud``.
 - The sensu.sensu_go collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/sensu/sensu-go-ansible/issues/362>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8380 <https://forum.ansible.com/t/8380>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install sensu.sensu_go``.
 
 Ansible-core
 ~~~~~~~~~~~~

--- a/9/CHANGELOG-v9.md
+++ b/9/CHANGELOG-v9.md
@@ -792,6 +792,7 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 * The google\.cloud collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements\.
   The collection has [unresolved sanity test failures](https\://github\.com/ansible\-collections/google\.cloud/issues/613)\.
   See [Collections Removal Process for collections not satisfying the collection requirements](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#collections\-not\-satisfying\-the\-collection\-requirements) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/8609](https\://forum\.ansible\.com/t/8609)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install google\.cloud</code>\.
 
 <a id="community-network"></a>
 #### community\.network
@@ -1230,6 +1231,7 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 * The sensu\.sensu\_go collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements\.
   The collection has [unresolved sanity test failures](https\://github\.com/sensu/sensu\-go\-ansible/issues/362)\.
   See [Collections Removal Process for collections not satisfying the collection requirements](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#collections\-not\-satisfying\-the\-collection\-requirements) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/8380](https\://forum\.ansible\.com/t/8380)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install sensu\.sensu\_go</code>\.
 
 <a id="bugfixes-2"></a>
 ### Bugfixes
@@ -5447,8 +5449,10 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 
 * The <code>inspur\.sm</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
   See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/2854](https\://forum\.ansible\.com/t/2854)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install inspur\.sm</code>\.
 * The <code>netapp\.storagegrid</code> collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11\.
   See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://forum\.ansible\.com/t/2811](https\://forum\.ansible\.com/t/2811)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install netapp\.storagegrid</code>\.
 * The <code>purestorage\.fusion</code> collection has been deprecated\.
   It will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
   See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details \([https\://forum\.ansible\.com/t/3712](https\://forum\.ansible\.com/t/3712)\)\.
@@ -7636,6 +7640,8 @@ This is the same version of ansible\-core as in the previous Ansible release\.
 * ngine\_io\.vultr \(previously included version\: 1\.1\.3\)
 * servicenow\.servicenow \(previously included version\: 1\.0\.6\)
 
+You can still install a removed collection manually with <code>ansible\-galaxy collection install \<name\-of\-collection\></code>\.
+
 <a id="added-collections-3"></a>
 ### Added Collections
 
@@ -9312,14 +9318,19 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 
 * The <code>community\.azure</code> collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
   See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://github\.com/ansible\-community/community\-topics/issues/263](https\://github\.com/ansible\-community/community\-topics/issues/263)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install community\.azure</code>\.
 * The <code>hpe\.nimble</code> collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
   See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://github\.com/ansible\-community/community\-topics/issues/254](https\://github\.com/ansible\-community/community\-topics/issues/254)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install hpe\.nimble</code>\.
 * The <code>netapp\.azure</code> collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
   See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://github\.com/ansible\-community/community\-topics/issues/234](https\://github\.com/ansible\-community/community\-topics/issues/234)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install netapp\.azure</code>\.
 * The <code>netapp\.elementsw</code> collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
   See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://github\.com/ansible\-community/community\-topics/issues/235](https\://github\.com/ansible\-community/community\-topics/issues/235)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install netapp\.elementsw</code>\.
 * The <code>netapp\.um\_info</code> collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10\.
   See [Collections Removal Process for unmaintained collections](https\://docs\.ansible\.com/ansible/devel/community/collection\_contributors/collection\_package\_removal\.html\#unmaintained\-collections) for more details\, including for how this can be cancelled \([https\://github\.com/ansible\-community/community\-topics/issues/244](https\://github\.com/ansible\-community/community\-topics/issues/244)\)\.
+  After removal\, users can still install this collection with <code>ansible\-galaxy collection install netapp\.um\_info</code>\.
 * The collection <code>community\.sap</code> was renamed to <code>community\.sap\_libs</code>\.
   For now both collections are included in Ansible\.
   The collection will be completely removed from Ansible 10\.

--- a/9/CHANGELOG-v9.rst
+++ b/9/CHANGELOG-v9.rst
@@ -596,6 +596,7 @@ Deprecated Features
 - The google.cloud collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/ansible-collections/google.cloud/issues/613>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8609 <https://forum.ansible.com/t/8609>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install google.cloud``.
 
 community.network
 ~~~~~~~~~~~~~~~~~
@@ -1022,6 +1023,7 @@ Deprecated Features
 - The sensu.sensu_go collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/sensu/sensu-go-ansible/issues/362>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8380 <https://forum.ansible.com/t/8380>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install sensu.sensu_go``.
 
 Bugfixes
 --------
@@ -5074,8 +5076,10 @@ Deprecated Features
 
 - The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2854 <https://forum.ansible.com/t/2854>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
 - The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2811 <https://forum.ansible.com/t/2811>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
 - The ``purestorage.fusion`` collection has been deprecated.
   It will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/3712 <https://forum.ansible.com/t/3712>`__).
@@ -6978,6 +6982,8 @@ Removed Collections
 - ngine_io.vultr (previously included version: 1.1.3)
 - servicenow.servicenow (previously included version: 1.0.6)
 
+You can still install a removed collection manually with ``ansible-galaxy collection install <name-of-collection>``.
+
 Added Collections
 -----------------
 
@@ -8735,14 +8741,19 @@ Deprecated Features
 
 - The ``community.azure`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/263 <https://github.com/ansible-community/community-topics/issues/263>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install community.azure``.
 - The ``hpe.nimble`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/254 <https://github.com/ansible-community/community-topics/issues/254>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install hpe.nimble``.
 - The ``netapp.azure`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/234 <https://github.com/ansible-community/community-topics/issues/234>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install netapp.azure``.
 - The ``netapp.elementsw`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/235 <https://github.com/ansible-community/community-topics/issues/235>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install netapp.elementsw``.
 - The ``netapp.um_info`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/244 <https://github.com/ansible-community/community-topics/issues/244>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install netapp.um_info``.
 - The collection ``community.sap`` was renamed to ``community.sap_libs``.
   For now both collections are included in Ansible.
   The collection will be completely removed from Ansible 10.

--- a/9/porting_guide_9.rst
+++ b/9/porting_guide_9.rst
@@ -120,6 +120,7 @@ Deprecated Features
 - The google.cloud collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/ansible-collections/google.cloud/issues/613>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8609 <https://forum.ansible.com/t/8609>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install google.cloud``.
 
 community.network
 ~~~~~~~~~~~~~~~~~
@@ -144,6 +145,7 @@ Deprecated Features
 - The sensu.sensu_go collection will be removed from Ansible 12 due to violations of the Ansible inclusion requirements.
   The collection has \ `unresolved sanity test failures <https://github.com/sensu/sensu-go-ansible/issues/362>`__.
   See `Collections Removal Process for collections not satisfying the collection requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#collections-not-satisfying-the-collection-requirements>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/8380 <https://forum.ansible.com/t/8380>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install sensu.sensu_go``.
 
 Porting Guide for v9.10.0
 =========================
@@ -384,8 +386,10 @@ Deprecated Features
 
 - The ``inspur.sm`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2854 <https://forum.ansible.com/t/2854>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install inspur.sm``.
 - The ``netapp.storagegrid`` collection is considered unmaintained and will be removed from Ansible 11 if no one starts maintaining it again before Ansible 11.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://forum.ansible.com/t/2811 <https://forum.ansible.com/t/2811>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install netapp.storagegrid``.
 - The ``purestorage.fusion`` collection has been deprecated.
   It will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details (`https://forum.ansible.com/t/3712 <https://forum.ansible.com/t/3712>`__).
@@ -740,6 +744,8 @@ Removed Collections
 - ngine_io.vultr (previously included version: 1.1.3)
 - servicenow.servicenow (previously included version: 1.0.6)
 
+You can still install a removed collection manually with ``ansible-galaxy collection install <name-of-collection>``.
+
 Removed Features
 ----------------
 
@@ -873,14 +879,19 @@ Deprecated Features
 
 - The ``community.azure`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/263 <https://github.com/ansible-community/community-topics/issues/263>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install community.azure``.
 - The ``hpe.nimble`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/254 <https://github.com/ansible-community/community-topics/issues/254>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install hpe.nimble``.
 - The ``netapp.azure`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/234 <https://github.com/ansible-community/community-topics/issues/234>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install netapp.azure``.
 - The ``netapp.elementsw`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/235 <https://github.com/ansible-community/community-topics/issues/235>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install netapp.elementsw``.
 - The ``netapp.um_info`` collection is considered unmaintained and will be removed from Ansible 10 if no one starts maintaining it again before Ansible 10.
   See `Collections Removal Process for unmaintained collections <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_package_removal.html#unmaintained-collections>`__ for more details, including for how this can be cancelled (`https://github.com/ansible-community/community-topics/issues/244 <https://github.com/ansible-community/community-topics/issues/244>`__).
+  After removal, users can still install this collection with ``ansible-galaxy collection install netapp.um_info``.
 - The collection ``community.sap`` was renamed to ``community.sap_libs``.
   For now both collections are included in Ansible.
   The collection will be completely removed from Ansible 10.


### PR DESCRIPTION
Updated with the changes in https://github.com/ansible-community/antsibull-build/pull/647.