### PR TITLE
Restrict vmware.vmware to < 1.10.1 because 1.10.1 is not tagged

### DIFF
--- a/11/ansible-11.constraints
+++ b/11/ansible-11.constraints
@@ -1,0 +1,2 @@
+# vmware.vmware 1.10.1 is not tagged (https://github.com/ansible-collections/vmware.vmware/issues/124)
+vmware.vmware: <1.10.1

--- a/12/ansible-12.constraints
+++ b/12/ansible-12.constraints
@@ -1,0 +1,2 @@
+# vmware.vmware 1.10.1 is not tagged (https://github.com/ansible-collections/vmware.vmware/issues/124)
+vmware.vmware: <1.10.1

--- a/8/ansible-8.constraints
+++ b/8/ansible-8.constraints
@@ -1,3 +1,6 @@
 # cyberark.conjur 1.3.1 no longer is compatible with Python 3.9, which is used for the bytecompile test in antsibull-build for Ansible 8,
 # and happens to be the minimum required controller Python version supported by ansible-core 2.15, on which Ansible 8 is based.
 cyberark.conjur: <1.3.1
+
+# vmware.vmware 1.10.1 is not tagged (https://github.com/ansible-collections/vmware.vmware/issues/124)
+vmware.vmware: <1.10.1


### PR DESCRIPTION
Ref: https://github.com/ansible-collections/vmware.vmware/issues/124
Ref: https://github.com/ansible-community/ansible-build-data/issues/223#issuecomment-2679143897