### PR TITLE
Remove restriction of ibm.storage_virtualize to <2.7.2

### DIFF
--- a/11/ansible-11.constraints
+++ b/11/ansible-11.constraints
@@ -1,2 +1,0 @@
-# ibm.storage_virtualize 2.7.2 is not tagged (https://github.com/ansible-collections/ibm.storage_virtualize/issues/57)
-ibm.storage_virtualize: <2.7.2

--- a/12/ansible-12.constraints
+++ b/12/ansible-12.constraints
@@ -1,2 +1,0 @@
-# ibm.storage_virtualize 2.7.2 is not tagged (https://github.com/ansible-collections/ibm.storage_virtualize/issues/57)
-ibm.storage_virtualize: <2.7.2


### PR DESCRIPTION
Closes https://github.com/ansible-collections/ibm.storage_virtualize/issues/57.

Ref: #223