### PR TITLE
[WIP] Add community.proxmox to Ansible 11 and 12

### DIFF
--- a/11/ansible-11.build
+++ b/11/ansible-11.build
@@ -41,6 +41,7 @@ community.mysql: >=3.10.0,<4.0.0
 community.network: >=5.1.0,<6.0.0
 community.okd: >=4.0.0,<5.0.0
 community.postgresql: >=3.7.0,<4.0.0
+community.proxmox: >=1.0.0,<2.0.0
 community.proxysql: >=1.6.0,<2.0.0
 community.rabbitmq: >=1.3.0,<2.0.0
 community.routeros: >=3.0.0,<4.0.0

--- a/11/ansible.in
+++ b/11/ansible.in
@@ -38,6 +38,7 @@ community.mysql
 community.network
 community.okd
 community.postgresql
+community.proxmox
 community.proxysql
 community.rabbitmq
 community.routeros

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -152,6 +152,8 @@ collections:
     repository: https://github.com/openshift/community.okd
   community.postgresql:
     repository: https://github.com/ansible-collections/community.postgresql
+  community.proxmox:
+    repository: https://github.com/ansible-collections/community.proxmox
   community.proxysql:
     repository: https://github.com/ansible-collections/community.proxysql
   community.rabbitmq:

--- a/12/ansible-12.build
+++ b/12/ansible-12.build
@@ -39,6 +39,7 @@ community.mongodb: >=1.7.0,<2.0.0
 community.mysql: >=3.13.0,<4.0.0
 community.okd: >=4.0.0,<5.0.0
 community.postgresql: >=4.0.0,<5.0.0
+community.proxmox: >=1.0.0,<2.0.0
 community.proxysql: >=1.6.0,<2.0.0
 community.rabbitmq: >=1.4.0,<2.0.0
 community.routeros: >=3.6.0,<4.0.0

--- a/12/ansible.in
+++ b/12/ansible.in
@@ -36,6 +36,7 @@ community.mongodb
 community.mysql
 community.okd
 community.postgresql
+community.proxmox
 community.proxysql
 community.rabbitmq
 community.routeros

--- a/12/collection-meta.yaml
+++ b/12/collection-meta.yaml
@@ -138,6 +138,8 @@ collections:
     repository: https://github.com/openshift/community.okd
   community.postgresql:
     repository: https://github.com/ansible-collections/community.postgresql
+  community.proxmox:
+    repository: https://github.com/ansible-collections/community.proxmox
   community.proxysql:
     repository: https://github.com/ansible-collections/community.proxysql
   community.rabbitmq:


### PR DESCRIPTION
The proxmox content from community.general is about to be moved to community.proxmox. According to our rules, this allows community.proxmox to be added to Ansible without going through the review process.

Ref: https://github.com/ansible-collections/community.proxmox/issues/10

(CI will fail right now since community.proxmox hasn't been released so far.)