### PR TITLE
Announce removal of cisco.ise from Ansible 12 in Ansible 11

### DIFF
--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -63,6 +63,11 @@ collections:
       - racampos
       - jbogarin
     repository: https://github.com/CiscoISE/ansible-ise
+    removal:
+      major_version: 12
+      announce_version: 11.8.0
+      reason: considered-unmaintained
+      discussion: https://forum.ansible.com/t/43367
   cisco.meraki:
     repository: https://github.com/meraki/dashboard-api-ansible
   cisco.mso:

--- a/12/collection-meta.yaml
+++ b/12/collection-meta.yaml
@@ -351,6 +351,7 @@ removed_collections:
       version: 12.0.0a7
       reason: considered-unmaintained
       discussion: https://forum.ansible.com/t/43367
+      announce_version: 11.8.0
   cisco.nso:
     repository: https://github.com/CiscoDevNet/ansible-nso
     removal:


### PR DESCRIPTION
Ref: https://github.com/ansible-community/ansible-build-data/pull/559#pullrequestreview-2948183511

To be merged when Ansible 11.8.0 comes up and cisco.ise still has no updates/progress.