### PR TITLE
Run Ansible test builds daily

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -9,9 +9,9 @@ name: antsibull-build
     branches: [main]
   pull_request:
     branches: [main]
-  # Run once per week (Thursday at 04:00 UTC)
+  # Run once per day (at 04:00 UTC)
   schedule:
-    - cron: '0 4 * * 4'
+    - cron: '0 4 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/nox.yml
+++ b/.github/workflows/nox.yml
@@ -9,9 +9,9 @@ name: nox
     branches: [main]
   pull_request:
     branches: [main]
-  # Run once per week (Thursday at 04:00 UTC)
+  # Run once per week (Thursday at 04:15 UTC)
   schedule:
-    - cron: '0 4 * * 4'
+    - cron: '15 4 * * 4'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Right now they run once per week (on Thursday), which can be problematic if a bad release happens afterwards and before the next release (which is usually on Tuesday). I think it would be better to run the test builds daily so we find out early about problems.