### PR TITLE
Ansible 12: Cancel google.cloud removal

### DIFF
--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -226,9 +226,6 @@ collections:
       announce_version: 11.0.0b1
       reason: guidelines-violation
       discussion: https://forum.ansible.com/t/8609
-      reason_text: >
-        The collection has
-        L(unresolved sanity test failures, https://github.com/ansible-collections/google.cloud/issues/613).
       updates:
         - cancelled_version: 11.8.0
           reason_text: The sanity test failures have been addressed.

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -229,6 +229,9 @@ collections:
       reason_text: >
         The collection has
         L(unresolved sanity test failures, https://github.com/ansible-collections/google.cloud/issues/613).
+      updates:
+        - cancelled_version: 11.8.0
+          reason_text: The sanity test failures have been addressed.
   grafana.grafana:
     maintainers:
       - ishanjainn

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -230,7 +230,7 @@ collections:
         The collection has
         L(unresolved sanity test failures, https://github.com/ansible-collections/google.cloud/issues/613).
       updates:
-        - cancelled_version: 11.8.0
+        - cancelled_version: 11.9.0
           reason_text: The sanity test failures have been addressed.
   grafana.grafana:
     maintainers:

--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -226,6 +226,9 @@ collections:
       announce_version: 11.0.0b1
       reason: guidelines-violation
       discussion: https://forum.ansible.com/t/8609
+      reason_text: >
+        The collection has
+        L(unresolved sanity test failures, https://github.com/ansible-collections/google.cloud/issues/613).
       updates:
         - cancelled_version: 11.8.0
           reason_text: The sanity test failures have been addressed.

--- a/12/ansible-12.build
+++ b/12/ansible-12.build
@@ -57,6 +57,7 @@ dellemc.unity: >=2.0.0,<3.0.0
 f5networks.f5_modules: >=1.37.0,<2.0.0
 fortinet.fortimanager: >=2.10.0,<3.0.0
 fortinet.fortios: >=2.4.0,<3.0.0
+google.cloud: >=1.0.0,<2.0.0
 grafana.grafana: >=6.0.0,<7.0.0
 hetzner.hcloud: >=5.1.0,<6.0.0
 hitachivantara.vspone_block: >=3.5.0,<4.0.0

--- a/12/ansible.in
+++ b/12/ansible.in
@@ -54,6 +54,7 @@ dellemc.unity
 f5networks.f5_modules
 fortinet.fortimanager
 fortinet.fortios
+google.cloud
 grafana.grafana
 hetzner.hcloud
 hitachivantara.vspone_block

--- a/12/collection-meta.yaml
+++ b/12/collection-meta.yaml
@@ -458,13 +458,6 @@ removed_collections:
       announce_version: 7.7.0
   google.cloud:
     repository: https://github.com/ansible-collections/google.cloud
-    removal:
-      version: 12.0.0a1
-      reason: guidelines-violation
-      discussion: https://forum.ansible.com/t/8609
-      reason_text: >
-        The collection has
-        L(unresolved sanity test failures, https://github.com/ansible-collections/google.cloud/issues/613).
   hpe.nimble:
     maintainers:
       - ar-india

--- a/12/collection-meta.yaml
+++ b/12/collection-meta.yaml
@@ -199,6 +199,16 @@ collections:
     repository: https://github.com/fortinet-ansible-dev/ansible-galaxy-fortimanager-collection
   fortinet.fortios:
     repository: https://github.com/fortinet-ansible-dev/ansible-galaxy-fortios-collection
+  google.cloud:
+    repository: https://github.com/ansible-collections/google.cloud
+    removal:
+      major_version: 12
+      reason: guidelines-violation
+      discussion: https://forum.ansible.com/t/8609
+      updates:
+        - removed_version: 12.0.0a1
+        - readded_version: 12.0.0b1
+          reason_text: The sanity test failures have been addressed.
   grafana.grafana:
     maintainers:
       - ishanjainn
@@ -456,8 +466,6 @@ removed_collections:
       reason: considered-unmaintained
       discussion: https://github.com/ansible-community/community-topics/issues/225
       announce_version: 7.7.0
-  google.cloud:
-    repository: https://github.com/ansible-collections/google.cloud
   hpe.nimble:
     maintainers:
       - ar-india

--- a/12/collection-meta.yaml
+++ b/12/collection-meta.yaml
@@ -205,6 +205,9 @@ collections:
       major_version: 12
       reason: guidelines-violation
       discussion: https://forum.ansible.com/t/8609
+      reason_text: >
+        The collection has
+        L(unresolved sanity test failures, https://github.com/ansible-collections/google.cloud/issues/613).
       updates:
         - removed_version: 12.0.0a1
         - readded_version: 12.0.0b1


### PR DESCRIPTION
Cancel the removal of google.cloud.

Depends on https://forum.ansible.com/t//8609/18