### PR TITLE
CI: don't stop other builds if one build fails in Ansible builds

### DIFF
--- a/.github/workflows/antsibull-build.yml
+++ b/.github/workflows/antsibull-build.yml
@@ -19,6 +19,7 @@ jobs:
     name: 'Build Ansible community distribution (${{ matrix.name }})'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           # Using ansible_version as X.99.0 since it is unreleased so new deps are generated


### PR DESCRIPTION
This makes it easier to see whether only one Ansible version is affected, or multiple ones.