### PR TITLE
Schedule ibm.qradar for removal in Ansible 13

### DIFF
--- a/11/collection-meta.yaml
+++ b/11/collection-meta.yaml
@@ -250,6 +250,11 @@ collections:
     repository: https://github.com/hitachi-vantara/vspone-block-ansible
   ibm.qradar:
     repository: https://github.com/ansible-collections/ibm.qradar
+    removal:
+      major_version: 13
+      reason: deprecated
+      announce_version: 11.9.0
+      discussion: https://forum.ansible.com/t/44259
   ibm.spectrum_virtualize:
     maintainers:
       - Shilpi-J

--- a/12/collection-meta.yaml
+++ b/12/collection-meta.yaml
@@ -225,6 +225,11 @@ collections:
     repository: https://github.com/hitachi-vantara/vspone-block-ansible
   ibm.qradar:
     repository: https://github.com/ansible-collections/ibm.qradar
+    removal:
+      major_version: 13
+      reason: deprecated
+      announce_version: 12.0.0b4
+      discussion: https://forum.ansible.com/t/44259
   ibm.storage_virtualize:
     maintainers:
       - sumitguptaibm


### PR DESCRIPTION
`ibm.qradar` has been officially deprecated (see [The Bullhorn #197](https://forum.ansible.com/t/44261)), so let's remove it from the community package.

Relates: https://forum.ansible.com/t/44259