### PR TITLE
Remove deprecated cisco.dnac from Ansible 14

### DIFF
--- a/13/collection-meta.yaml
+++ b/13/collection-meta.yaml
@@ -53,6 +53,11 @@ collections:
       - racampos
       - wastorga
     repository: https://github.com/cisco-en-programmability/dnacenter-ansible
+    removal:
+      major_version: 14
+      reason: deprecated
+      announce_version: 13.6.0
+      discussion: https://forum.ansible.com/t/45609
   cisco.intersight:
     repository: https://github.com/CiscoDevNet/intersight-ansible
   cisco.ios:

--- a/14/ansible.in
+++ b/14/ansible.in
@@ -8,7 +8,6 @@ azure.azcollection
 check_point.mgmt
 chocolatey.chocolatey
 cisco.aci
-cisco.dnac
 cisco.intersight
 cisco.ios
 cisco.iosxr

--- a/14/collection-meta.yaml
+++ b/14/collection-meta.yaml
@@ -36,11 +36,6 @@ collections:
     collection-directory: "./chocolatey"
   cisco.aci:
     repository: https://github.com/CiscoDevNet/ansible-aci
-  cisco.dnac:
-    maintainers:
-      - racampos
-      - wastorga
-    repository: https://github.com/cisco-en-programmability/dnacenter-ansible
   cisco.intersight:
     repository: https://github.com/CiscoDevNet/intersight-ansible
   cisco.ios:
@@ -353,6 +348,16 @@ removed_collections:
       reason: deprecated
       discussion: https://forum.ansible.com/t/38960
       announce_version: 11.2.0
+  cisco.dnac:
+    maintainers:
+      - racampos
+      - wastorga
+    repository: https://github.com/cisco-en-programmability/dnacenter-ansible
+    removal:
+      version: 14.0.0a2
+      reason: deprecated
+      announce_version: 13.6.0
+      discussion: https://forum.ansible.com/t/45609
   cisco.ise:
     maintainers:
       - wastorga

--- a/14/collection-meta.yaml
+++ b/14/collection-meta.yaml
@@ -354,7 +354,7 @@ removed_collections:
       - wastorga
     repository: https://github.com/cisco-en-programmability/dnacenter-ansible
     removal:
-      version: 14.0.0a2
+      version: 14.0.0a1
       reason: deprecated
       announce_version: 13.6.0
       discussion: https://forum.ansible.com/t/45609


### PR DESCRIPTION
Remove [deprecated](https://github.com/cisco-en-programmability/dnacenter-ansible/pull/324) collection `cisco.dnac` from Ansible 14.

Ref: https://forum.ansible.com/t/45609

Like #660 but with (I hope correctly) updated versions.