### PR TITLE
Pin hitachivantara.vspone_block to < 4.7.0

### DIFF
--- a/13/ansible-13.constraints
+++ b/13/ansible-13.constraints
@@ -10,3 +10,5 @@ junipernetworks.junos: <11.1.0
 # how to proceed.
 # https://github.com/cisco-en-programmability/dnacenter-ansible/issues/327
 cisco.dnac: <6.48.1
+# hitachivantara.vspone_block 4.7.0 contains breaking changes
+hitachivantara.vspone_block: <4.7.0

--- a/14/ansible-14.constraints
+++ b/14/ansible-14.constraints
@@ -1,0 +1,2 @@
+# hitachivantara.vspone_block 4.7.0 contains breaking changes
+hitachivantara.vspone_block: <4.7.0


### PR DESCRIPTION
hitachivantara.vspone_block apparently contains breaking changes: https://github.com/hitachi-vantara/vspone-block-ansible/blob/main/CHANGELOG.rst#v4-7-0

Ref: #223