### PR TITLE
Restrict cyberark.pas to < 1.0.40

### DIFF
--- a/13/ansible-13.constraints
+++ b/13/ansible-13.constraints
@@ -10,3 +10,5 @@ junipernetworks.junos: <11.1.0
 # how to proceed.
 # https://github.com/cisco-en-programmability/dnacenter-ansible/issues/327
 cisco.dnac: <6.48.1
+# cyberark.pas 1.0.40 is not tagged in https://github.com/cyberark/ansible-security-automation-collection
+cyberark.pas: <1.0.40

--- a/14/ansible-14.constraints
+++ b/14/ansible-14.constraints
@@ -1,0 +1,2 @@
+# cyberark.pas 1.0.40 is not tagged in https://github.com/cyberark/ansible-security-automation-collection
+cyberark.pas: <1.0.40


### PR DESCRIPTION
1.0.40 hasn't been tagged.

Ref: #223