### PR TITLE
Ansible 14: restrict community.mysql to < 5.0.0

### DIFF
--- a/13/CHANGELOG-v13.md
+++ b/13/CHANGELOG-v13.md
@@ -459,7 +459,7 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 * The collection <code>community\.mysql</code> was renamed to <code>ansible\.mysql</code>\.
   For now both collections are included in Ansible\.
   The content in <code>community\.mysql</code> will be replaced by deprecated redirects in Ansible 15\.0\.0\.
-  The collection will be completely removed from Ansible 16\.
+  The collection will be completely removed from Ansible 17\.
   Please update your FQCNs from <code>community\.mysql</code> to <code>ansible\.mysql</code> \([https\://forum\.ansible\.com/t/45798](https\://forum\.ansible\.com/t/45798)\)\.
 
 <a id="arista-eos-1"></a>

--- a/13/CHANGELOG-v13.md
+++ b/13/CHANGELOG-v13.md
@@ -458,7 +458,7 @@ If not mentioned explicitly\, the changes are reported in the combined changelog
 
 * The collection <code>community\.mysql</code> was renamed to <code>ansible\.mysql</code>\.
   For now both collections are included in Ansible\.
-  The content in <code>community\.mysql</code> will be replaced by deprecated redirects in Ansible 14\.0\.0\.
+  The content in <code>community\.mysql</code> will be replaced by deprecated redirects in Ansible 15\.0\.0\.
   The collection will be completely removed from Ansible 16\.
   Please update your FQCNs from <code>community\.mysql</code> to <code>ansible\.mysql</code> \([https\://forum\.ansible\.com/t/45798](https\://forum\.ansible\.com/t/45798)\)\.
 

--- a/13/CHANGELOG-v13.rst
+++ b/13/CHANGELOG-v13.rst
@@ -327,7 +327,7 @@ Deprecated Features
 
 - The collection ``community.mysql`` was renamed to ``ansible.mysql``.
   For now both collections are included in Ansible.
-  The content in ``community.mysql`` will be replaced by deprecated redirects in Ansible 14.0.0.
+  The content in ``community.mysql`` will be replaced by deprecated redirects in Ansible 15.0.0.
   The collection will be completely removed from Ansible 16.
   Please update your FQCNs from ``community.mysql`` to ``ansible.mysql`` (`https://forum.ansible.com/t/45798 <https://forum.ansible.com/t/45798>`__).
 

--- a/13/CHANGELOG-v13.rst
+++ b/13/CHANGELOG-v13.rst
@@ -328,7 +328,7 @@ Deprecated Features
 - The collection ``community.mysql`` was renamed to ``ansible.mysql``.
   For now both collections are included in Ansible.
   The content in ``community.mysql`` will be replaced by deprecated redirects in Ansible 15.0.0.
-  The collection will be completely removed from Ansible 16.
+  The collection will be completely removed from Ansible 17.
   Please update your FQCNs from ``community.mysql`` to ``ansible.mysql`` (`https://forum.ansible.com/t/45798 <https://forum.ansible.com/t/45798>`__).
 
 arista.eos

--- a/13/collection-meta.yaml
+++ b/13/collection-meta.yaml
@@ -123,7 +123,7 @@ collections:
   community.mysql:
     repository: https://github.com/ansible-collections/community.mysql
     removal:
-      major_version: 16
+      major_version: 17
       reason: renamed
       new_name: ansible.mysql
       redirect_replacement_major_version: 15

--- a/13/collection-meta.yaml
+++ b/13/collection-meta.yaml
@@ -126,7 +126,7 @@ collections:
       major_version: 16
       reason: renamed
       new_name: ansible.mysql
-      redirect_replacement_major_version: 14
+      redirect_replacement_major_version: 15
       announce_version: 13.7.0
       discussion: https://forum.ansible.com/t/45798
   community.okd:

--- a/13/porting_guide_13.rst
+++ b/13/porting_guide_13.rst
@@ -295,7 +295,7 @@ Deprecated Features
 - The collection ``community.mysql`` was renamed to ``ansible.mysql``.
   For now both collections are included in Ansible.
   The content in ``community.mysql`` will be replaced by deprecated redirects in Ansible 15.0.0.
-  The collection will be completely removed from Ansible 16.
+  The collection will be completely removed from Ansible 17.
   Please update your FQCNs from ``community.mysql`` to ``ansible.mysql`` (`https://forum.ansible.com/t/45798 <https://forum.ansible.com/t/45798>`__).
 
 arista.eos

--- a/13/porting_guide_13.rst
+++ b/13/porting_guide_13.rst
@@ -294,7 +294,7 @@ Deprecated Features
 
 - The collection ``community.mysql`` was renamed to ``ansible.mysql``.
   For now both collections are included in Ansible.
-  The content in ``community.mysql`` will be replaced by deprecated redirects in Ansible 14.0.0.
+  The content in ``community.mysql`` will be replaced by deprecated redirects in Ansible 15.0.0.
   The collection will be completely removed from Ansible 16.
   Please update your FQCNs from ``community.mysql`` to ``ansible.mysql`` (`https://forum.ansible.com/t/45798 <https://forum.ansible.com/t/45798>`__).
 

--- a/14/ansible-14.constraints
+++ b/14/ansible-14.constraints
@@ -1,2 +1,4 @@
 # cyberark.pas 1.0.40 is not tagged in https://github.com/cyberark/ansible-security-automation-collection
 cyberark.pas: <1.0.40
+# community.mysql 5.0.x is incompatible with ansible.mysql 5.x.y
+community.mysql: <5.0.0

--- a/14/collection-meta.yaml
+++ b/14/collection-meta.yaml
@@ -104,7 +104,7 @@ collections:
       major_version: 16
       reason: renamed
       new_name: ansible.mysql
-      redirect_replacement_major_version: 14
+      redirect_replacement_major_version: 15
       announce_version: 14.0.0b1
       discussion: https://forum.ansible.com/t/45798
   community.okd:

--- a/14/collection-meta.yaml
+++ b/14/collection-meta.yaml
@@ -101,7 +101,7 @@ collections:
   community.mysql:
     repository: https://github.com/ansible-collections/community.mysql
     removal:
-      major_version: 16
+      major_version: 17
       reason: renamed
       new_name: ansible.mysql
       redirect_replacement_major_version: 15


### PR DESCRIPTION
In case @Andersson007 does not respond to the questions in the community matrix room, we need to either restrict ansibe.mysql to < 5.0.0, or community.mysql to < 5.0.0. I think the latter is better.