### PR TITLE
Specify collection-directory for graphiant.nas (take 2)

### DIFF
--- a/13/collection-meta.yaml
+++ b/13/collection-meta.yaml
@@ -218,7 +218,7 @@ collections:
     repository: https://github.com/grafana/grafana-ansible-collection
   graphiant.naas:
     repository: https://github.com/Graphiant-Inc/graphiant-playbooks
-    collection-directory: "ansible_collections/graphiant/naas"
+    collection-directory: "./ansible_collections/graphiant/naas"
   hetzner.hcloud:
     repository: https://github.com/ansible-collections/hetzner.hcloud
   hitachivantara.vspone_block:

--- a/14/ansible-14.0.0rc1-tags.yaml
+++ b/14/ansible-14.0.0rc1-tags.yaml
@@ -228,6 +228,7 @@ grafana.grafana:
   tag: 6.1.0
   version: 6.1.0
 graphiant.naas:
+  collection_directory: ./ansible_collections/graphiant/naas
   repository: https://github.com/Graphiant-Inc/graphiant-playbooks
   tag: v26.4.0
   version: 26.4.0

--- a/14/collection-meta.yaml
+++ b/14/collection-meta.yaml
@@ -196,7 +196,7 @@ collections:
     repository: https://github.com/grafana/grafana-ansible-collection
   graphiant.naas:
     repository: https://github.com/Graphiant-Inc/graphiant-playbooks
-    collection-directory: "ansible_collections/graphiant/naas"
+    collection-directory: "./ansible_collections/graphiant/naas"
   hetzner.hcloud:
     repository: https://github.com/ansible-collections/hetzner.hcloud
   hitachivantara.vspone_block:


### PR DESCRIPTION
This is needed for the
https://github.com/ansible-community/package-test-results workflow.

Technically, prefixing the path with `./` is not required by the code in antsibull-build, but this was done for consistency with the other `collection-directory` entries that do have the prefix.