### PR TITLE
Restrict purestorage.flashblade to <1.28.0

### DIFF
--- a/13/ansible-13.constraints
+++ b/13/ansible-13.constraints
@@ -18,3 +18,5 @@ community.mysql: <4.3.0
 # Potentially breaking change in changelog for 3.23.0
 # - This changes the behavior for generating slugs. If you were relying on the previous behavior, you need to be aware that this behavior has changed.
 netbox.netbox: <3.23.0
+# purestorage.flashblade 1.28.0 replaced all contents by redirects, and added a new dependency
+purestorage.flashblade: <1.28.0

--- a/14/ansible-14.constraints
+++ b/14/ansible-14.constraints
@@ -1,2 +1,4 @@
 # cyberark.pas 1.0.40 is not tagged in https://github.com/cyberark/ansible-security-automation-collection
 cyberark.pas: <1.0.40
+# purestorage.flashblade 1.28.0 replaced all contents by redirects, and added a new dependency
+purestorage.flashblade: <1.28.0

--- a/15/ansible-15.constraints
+++ b/15/ansible-15.constraints
@@ -1,0 +1,2 @@
+# purestorage.flashblade 1.28.0 replaced all contents by redirects, and added a new dependency
+purestorage.flashblade: <1.28.0


### PR DESCRIPTION
Release 1.28.0 added a new dependency (everpure.flashblade >=1.27.0,<2.0.0) and replaced all its content with redirects to that collection. It also isn't tagged in the repository.