### PR TITLE
Restrict purestorage.flasharray to < 1.45.0

### DIFF
--- a/14/ansible-14.constraints
+++ b/14/ansible-14.constraints
@@ -2,3 +2,5 @@
 cyberark.pas: <1.0.40
 # purestorage.flashblade 1.28.0 replaced all contents by redirects, and added a new dependency
 purestorage.flashblade: <1.28.0
+# purestorage.flasharray 1.45.0 replaced all contents by redirects, and added a new dependency; also there is no corresponding tag
+purestorage.flasharray: <1.45.0

--- a/15/ansible-15.constraints
+++ b/15/ansible-15.constraints
@@ -1,2 +1,4 @@
 # purestorage.flashblade 1.28.0 replaced all contents by redirects, and added a new dependency
 purestorage.flashblade: <1.28.0
+# purestorage.flasharray 1.45.0 replaced all contents by redirects, and added a new dependency; also there is no corresponding tag
+purestorage.flasharray: <1.45.0

--- a/9/ansible-9.constraints
+++ b/9/ansible-9.constraints
@@ -4,3 +4,5 @@ cisco.dnac: <6.32.0
 cyberark.pas: <1.0.40
 # purestorage.flashblade 1.28.0 replaced all contents by redirects, and added a new dependency
 purestorage.flashblade: <1.28.0
+# purestorage.flasharray 1.45.0 replaced all contents by redirects, and added a new dependency; also there is no corresponding tag
+purestorage.flasharray: <1.45.0


### PR DESCRIPTION
purestorage.flasharray 1.45.0 is not tagged in the repo, which is now re-used for another collection.