### PR TITLE
Remove the hetzner.hcloud and ngine_io.cloudstack pins

### DIFF
--- a/14/ansible-14.constraints
+++ b/14/ansible-14.constraints
@@ -12,5 +12,5 @@ infoblox.nios_modules: <1.10.0
 netapp_eseries.santricity: <2.0.2
 # hetzner.hcloud 6.11.0 has a breaking change that was reverted in 6.12.0 (https://github.com/ansible-collections/hetzner.hcloud/issues/851)
 hetzner.hcloud: !=6.11.0
-# ngine_io.cloudstack 3.1.0 has a breaking change
-ngine_io.cloudstack: <3.1.0
+# ngine_io.cloudstack 3.1.0 has a breaking change that was reverted in 3.2.0 (https://github.com/ngine-io/ansible-collection-cloudstack/issues/180)
+ngine_io.cloudstack: !=3.1.0

--- a/14/ansible-14.constraints
+++ b/14/ansible-14.constraints
@@ -10,7 +10,7 @@ cyberark.conjur: <1.3.13
 infoblox.nios_modules: <1.10.0
 # netapp_eseries.santricity 2.0.2 has a breaking change
 netapp_eseries.santricity: <2.0.2
-# hetzner.hcloud 6.11.0 has a breaking change
-hetzner.hcloud: <6.11.0
+# hetzner.hcloud 6.11.0 has a breaking change that was reverted in 6.12.0 (https://github.com/ansible-collections/hetzner.hcloud/issues/851)
+hetzner.hcloud: !=6.11.0
 # ngine_io.cloudstack 3.1.0 has a breaking change
 ngine_io.cloudstack: <3.1.0

--- a/14/changelog.yaml
+++ b/14/changelog.yaml
@@ -89,7 +89,7 @@ remove_collection_changelog_entries:
   hetzner.hcloud:
     6.11.0:
       changes:
-        # All changes from the 6.11.0 changelog, since they were all reverted in 3.12.0.
+        # All changes from the 6.11.0 changelog, since they were all reverted in 6.12.0.
         minor_changes:
           - load_balancer - Print warning when creating a Load Balancer with a deprecated
             or unavailable Load Balancer Type.

--- a/14/changelog.yaml
+++ b/14/changelog.yaml
@@ -85,4 +85,33 @@ releases:
 
         `Porting Guide <https://docs.ansible.com/projects/ansible/devel/porting_guides.html>`_'
     release_date: '2026-08-14'
-remove_collection_changelog_entries: {}
+remove_collection_changelog_entries:
+  hetzner.hcloud:
+    6.11.0:
+      changes:
+        # All changes from the 6.11.0 changelog, since they were all reverted in 3.12.0.
+        minor_changes:
+          - load_balancer - Print warning when creating a Load Balancer with a deprecated
+            or unavailable Load Balancer Type.
+          - load_balancer_type_info - Added the Load Balancer Type ``deprecation`` object
+            to the return values (``load_balancer_type_info[].deprecation``).
+        removed_features:
+          - hcloud inventory - The deprecated ``hcloud_datacenter`` host variable was
+            removed. Please use the ``hcloud_location`` host variable instead.
+          - network_info - The deprecated ``hcloud_network_info[].servers[].datacenter``
+            return value was removed. Please use the ``hcloud_network_info[].servers[].location``
+            return value instead.
+          - primary_ip - The deprecated ``datacenter`` argument was removed. Please use
+            the ``location`` argument instead.
+          - primary_ip - The deprecated ``hcloud_primary_ip.datacenter`` return value
+            was removed. Please use the ``hcloud_primary_ip.location`` return value instead.
+          - primary_ip_info - The deprecated ``hcloud_primary_ip_info[].datacenter`` return
+            value was removed. Please use the ``hcloud_primary_ip_info[].location`` return
+            value instead.
+          - server - The deprecated ``datacenter`` argument was removed. Please use the
+            ``location`` argument instead.
+          - server - The deprecated ``hcloud_server.datacenter`` return value was removed.
+            Please use the ``hcloud_server.location`` return value instead.
+          - server_info - The deprecated ``hcloud_server_info[].datacenter`` return value
+            was removed. Please use the ``hcloud_server_info[].location`` return value
+            instead.

--- a/14/changelog.yaml
+++ b/14/changelog.yaml
@@ -115,3 +115,15 @@ remove_collection_changelog_entries:
           - server_info - The deprecated ``hcloud_server_info[].datacenter`` return value
             was removed. Please use the ``hcloud_server_info[].location`` return value
             instead.
+  ngine_io.cloudstack:
+    3.1.0:
+      changes:
+        removed_features:
+          - The deprecated routing to module names with ``cs_`` prefix has been removed.
+            Use the new module names instead.
+    3.2.0:
+      changes:
+        bugfixes:
+          - The removed routing to module names with ``cs_`` prefix instroduced in 3.1.0
+            has been restored. Backwards compatibility with existing playbooks is now
+            ensured.


### PR DESCRIPTION
### hetzner.cloud

Ref: https://github.com/ansible-collections/hetzner.hcloud/issues/851
Ref: https://github.com/ansible-collections/hetzner.hcloud/pull/852

The 6.12.0 release reverts all changes of 6.11.0, that's why I added the `remove_collection_changelog_entries` entry to actually remove all 6.1.10 changes from the combined changelog.

### ngine_io.cloudstack

Ref: https://github.com/ngine-io/ansible-collection-cloudstack/issues/180
Ref: https://github.com/ngine-io/ansible-collection-cloudstack/pull/181

The 3.2.0 release reverts the breaking change from the 3.1.0 release. I've used `remove_collection_changelog_entries` to remove the corresponding changelog entries.