### PR TITLE
Zizmor config: make linter happy

### DIFF
--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,3 +1,4 @@
+---
 rules:
   unpinned-uses:
     config:


### PR DESCRIPTION
Right now, the linter emits a warning that `---` is missing. Since it's a warning, it doesn't surface easily.